### PR TITLE
Fix some todos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,4 @@ jobs:
         with:
           distribution: "temurin" # See 'Supported distributions' for available options
           java-version: "17"
-      - name: Install `npm` tool
-        uses: actions/setup-node@v3
-        with:
-          node-version: "14"
-
       - run: ./release-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: |
+      - name: Install `changelog` tool
+        run: |
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           wget -qO- https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz | tar xvz -C $HOME/.local/bin changelog
+      - name: Install `mvn` tool
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin" # See 'Supported distributions' for available options
+          java-version: "17"
+      - name: Install `npm` tool
+        uses: actions/setup-node@v3
+        with:
+          node-version: "14"
 
       - run: ./release-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,4 @@ jobs:
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           wget -qO- https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz | tar xvz -C $HOME/.local/bin changelog
-      - name: Install `mvn` tool
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin" # See 'Supported distributions' for available options
-          java-version: "17"
       - run: ./release-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 
 *-actual.diff
+*-actual.output
 *.bak

--- a/01-expected.diff
+++ b/01-expected.diff
@@ -1,13 +1,12 @@
 diff --git a/test-fixture/CHANGELOG.md b/test-fixture/CHANGELOG.md
 --- a/test-fixture/CHANGELOG.md
 +++ b/test-fixture/CHANGELOG.md
-@@ -9,0 +10,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+@@ -9,0 +10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 +## [1.0.0] - 2022-04-07
-+
-@@ -12 +14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+@@ -15 +16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -## [0.0.0] - 2019-08-23
 +## 0.0.0 - 2019-08-23
-@@ -14 +16,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+@@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
 +[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main

--- a/01-expected.diff
+++ b/01-expected.diff
@@ -2,10 +2,10 @@ diff --git a/test-fixture/CHANGELOG.md b/test-fixture/CHANGELOG.md
 --- a/test-fixture/CHANGELOG.md
 +++ b/test-fixture/CHANGELOG.md
 @@ -9,0 +10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
-+## [1.0.0] - 2022-04-07
++## [1.0.0] - 2000-01-01
 @@ -15 +16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--## [0.0.0] - 2019-08-23
-+## 0.0.0 - 2019-08-23
+-## [0.0.0] - 2000-01-01
++## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main

--- a/02-expected.diff
+++ b/02-expected.diff
@@ -1,13 +1,12 @@
 diff --git a/test-fixture/CHANGELOG.md b/test-fixture/CHANGELOG.md
 --- a/test-fixture/CHANGELOG.md
 +++ b/test-fixture/CHANGELOG.md
-@@ -9,0 +10,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+@@ -9,0 +10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 +## [1.0.0] - 2022-04-07
-+
-@@ -12 +14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+@@ -15 +16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -## [0.0.0] - 2019-08-23
 +## 0.0.0 - 2019-08-23
-@@ -14 +16,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+@@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
 +[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main

--- a/02-expected.diff
+++ b/02-expected.diff
@@ -2,10 +2,10 @@ diff --git a/test-fixture/CHANGELOG.md b/test-fixture/CHANGELOG.md
 --- a/test-fixture/CHANGELOG.md
 +++ b/test-fixture/CHANGELOG.md
 @@ -9,0 +10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
-+## [1.0.0] - 2022-04-07
++## [1.0.0] - 2000-01-01
 @@ -15 +16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--## [0.0.0] - 2019-08-23
-+## 0.0.0 - 2019-08-23
+-## [0.0.0] - 2000-01-01
++## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main

--- a/03-expected.output
+++ b/03-expected.output
@@ -1,0 +1,15 @@
+Missing MAJOR.MINOR.PATCH argument. Please specify a version to release.
+
+Usage: ../release [OPTIONS] MAJOR.MINOR.PATCH
+OPTIONS:
+  --help                 shows this help
+  --no-git-push          do not push to git
+  --no-git-commit        do not commit git
+  --no-git-tag-check     do not check local git tags are up to date with CHANGELOG.md
+  --only-release         do not update versions after release
+
+To help you choose the next version, here are the unreleased changes:
+
+### Fixed
+- This is a test
+

--- a/release
+++ b/release
@@ -83,7 +83,7 @@ function validate_environment() {
    [[ -d java ]] && required_tools+=("mvn")
    for tool in ${required_tools[@]}
    do
-     if ! command -v $tool; then
+     if ! command -v $tool > /dev/null; then
        echo "$tool is not installed!"
        missing_tool="true"
      fi

--- a/release
+++ b/release
@@ -69,6 +69,23 @@ function validate_args() {
 }
 
 function validate_environment() {
+
+   required_tools=("git" "changelog")
+   [[ -d javascript ]] && required_tools+=("npm")
+   [[ -d java ]] && required_tools+=("mvn")
+   for tool in ${required_tools[@]}
+   do
+     if ! which -s $tool; then
+       echo "$tool is not installed!"
+       missing_tool="true"
+     fi
+   done
+   if [ "$missing_tool" ]; then
+     echo
+     echo "Please install the missing required tool(s)."
+     exit 1
+   fi
+
   if [[ (-z $NO_GIT_TAG_CHECK) && (-z "$(git tag --list "v$(changelog latest)")") ]]; then
     echo "No git tag found for v$(changelog latest) (found in CHANGELOG.md)!"
     echo

--- a/release
+++ b/release
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# quiet output from pushd / popd
+pushd () { 
+  command pushd "$@" > /dev/null
+}
+popd () { 
+  command popd "$@" > /dev/null
+}
+
 function release_javascript() {
   if [[ -d javascript ]]; then
     pushd javascript
@@ -80,7 +88,7 @@ function validate_environment() {
 # Integrity check (are all the tools installed?)
 # Present the user with the current version?
 # Show unreleased
-# Reduce the output from git and pushd/popo
+# Reduce the output from git
 
 # Version4:
 # Bootstrap from single git repo.

--- a/release
+++ b/release
@@ -83,7 +83,7 @@ function validate_environment() {
    [[ -d java ]] && required_tools+=("mvn")
    for tool in ${required_tools[@]}
    do
-     if ! which -s $tool; then
+     if ! command -v $tool; then
        echo "$tool is not installed!"
        missing_tool="true"
      fi

--- a/release
+++ b/release
@@ -1,27 +1,24 @@
 #!/bin/bash
 set -e
 
-# TODO:
-# Version4:
-# Bootstrap from single git repo.
-# Add tests
-
-# Version5:
-# Version bumping
-
 # quiet output from pushd / popd
-pushd () { 
-  command pushd "$@" > /dev/null
+pushd() {
+  command pushd "$@" >/dev/null
 }
-popd () { 
-  command popd "$@" > /dev/null
+popd() {
+  command popd "$@" >/dev/null
+}
+
+function pre_release_javascript() {
+  if [[ -d javascript ]]; then
+    check_for_tools "npm"
+  fi
 }
 
 function release_javascript() {
-  check_for_tools "npm"
   if [[ -d javascript ]]; then
     pushd javascript
-    npm version $NEW_VERSION > /dev/null
+    npm version $NEW_VERSION >/dev/null
     popd
   fi
 }
@@ -30,17 +27,21 @@ function post_release_javascript() {
   :
 }
 
+function pre_release_java() {
+  if [[ -d java ]]; then
+    check_for_tools "mvn"
+  fi
+}
+
 function release_java() {
-  check_for_tools "mvn"
   if [[ -d java ]]; then
     pushd java
-    mvn --quiet versions:set -DnewVersion="$NEW_VERSION" 2> /dev/null
-    mvn --quiet versions:set-scm-tag -DnewTag="v$NEW_VERSION" 2> /dev/null
+    mvn --quiet versions:set -DnewVersion="$NEW_VERSION" 2>/dev/null
+    mvn --quiet versions:set-scm-tag -DnewTag="v$NEW_VERSION" 2>/dev/null
     popd
   fi
 }
 function post_release_java() {
-  check_for_tools "mvn"
   if [[ -d java ]]; then
     pushd java
     new_version_template="\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT"
@@ -48,9 +49,14 @@ function post_release_java() {
       build-helper:parse-version \
       versions:set -DnewVersion="$new_version_template" \
       versions:set-scm-tag -DnewTag="HEAD" \
-      2> /dev/null
+      2>/dev/null
     popd
   fi
+}
+
+function pre_release_ruby() {
+  # noop
+  :
 }
 
 function release_ruby() {
@@ -80,9 +86,8 @@ function validate_new_version_argument() {
 }
 
 function check_for_tools() {
-  for tool in "$@"
-  do
-    if ! command -v $tool > /dev/null; then
+  for tool in "$@"; do
+    if ! command -v $tool >/dev/null; then
       echo "$tool is not installed!"
       missing_tool="true"
     fi
@@ -120,6 +125,14 @@ function show_usage() {
   echo "  --no-git-tag-check     do not check local git tags are up to date with CHANGELOG.md"
   echo "  --only-release         do not update versions after release"
 }
+
+# Unset variables
+NEW_VERSION=
+NO_GIT_TAG_CHECK=
+NO_GIT_PUSH=
+NO_GIT_TAG=
+ONLY_RELEASE=
+POSITIONAL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -173,6 +186,13 @@ if [[ $# -ne 1 ]]; then
 fi
 NEW_VERSION=$1
 validate_new_version_argument
+
+###
+## pre release
+###
+pre_release_javascript
+pre_release_java
+pre_release_ruby
 
 ###
 ## release

--- a/release
+++ b/release
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# TODO:
+# Version4:
+# Bootstrap from single git repo.
+# Add tests
+
+# Version5:
+# Version bumping
+
 # quiet output from pushd / popd
 pushd () { 
   command pushd "$@" > /dev/null
@@ -100,19 +108,7 @@ function validate_environment() {
   fi
 }
 
-# TODO:
-# Version3:
-# Integrity check (are all the tools installed?)
-# Present the user with the current version?
-# Show unreleased
-# Reduce the output from git
 
-# Version4:
-# Bootstrap from single git repo.
-# Add tests
-
-# Version5:
-# Version bumping
 function showUsage() {
   echo "Usage: $0 [OPTIONS] MAJOR.MINOR.PATCH"
   echo "OPTIONS:"

--- a/release
+++ b/release
@@ -43,10 +43,10 @@ function post_release_java() {
   check_for_tools "mvn"
   if [[ -d java ]]; then
     pushd java
-    NEW_VERSION_TEMPLATE="\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT"
+    new_version_template="\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT"
     mvn --quiet \
       build-helper:parse-version \
-      versions:set -DnewVersion="$NEW_VERSION_TEMPLATE" \
+      versions:set -DnewVersion="$new_version_template" \
       versions:set-scm-tag -DnewTag="HEAD" \
       2> /dev/null
     popd

--- a/release
+++ b/release
@@ -12,7 +12,7 @@ popd () {
 function release_javascript() {
   if [[ -d javascript ]]; then
     pushd javascript
-    npm version $NEW_VERSION
+    npm version $NEW_VERSION > /dev/null
     popd
   fi
 }

--- a/release
+++ b/release
@@ -41,9 +41,30 @@ function release_ruby() {
     popd
   fi
 }
+
 function post_release_ruby() {
   # noop
   :
+}
+
+function validate_args() {
+  if [[ ! "$NEW_VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo "Invalid MAJOR.MINOR.PATCH argument: $NEW_VERSION"
+    showUsage
+    exit 1
+  fi
+
+  if [ -n "$(git tag --list "v$NEW_VERSION")" ]; then
+    echo "Version $NEW_VERSION has already been released"
+    exit 1
+  fi
+}
+
+function validate_environment() {
+  if ! git diff-index --quiet HEAD; then
+    echo "Git has uncommitted changes"
+    exit 1
+  fi
 }
 
 # TODO:
@@ -102,35 +123,16 @@ done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
+validate_environment
+
 if [[ $# -ne 1 ]]; then
   echo "Missing MAJOR.MINOR.PATCH argument"
   showUsage
   exit 1
 fi
-
 NEW_VERSION=$1
 
-if [[ ! "$NEW_VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-  echo "Invalid MAJOR.MINOR.PATCH argument: $NEW_VERSION"
-  showUsage
-  exit 1
-fi
-
-if [[ ! "$NEW_VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-  echo "Invalid MAJOR.MINOR.PATCH argument: $NEW_VERSION"
-  showUsage
-  exit 1
-fi
-
-if [ -n "$(git tag --list "v$NEW_VERSION")" ]; then
-  echo "Version $NEW_VERSION has already been released"
-  exit 1
-fi
-
-if ! git diff-index --quiet HEAD; then
-  echo "Git has uncommitted changes"
-  exit 1
-fi
+validate_args
 
 ###
 ## release

--- a/release
+++ b/release
@@ -182,7 +182,7 @@ release_ruby
 changelog release "$NEW_VERSION" --tag-format "v%s" -o CHANGELOG.md
 
 if [[ -z $NO_GIT_COMMIT ]]; then
-  git commit -am "Prepare release v$NEW_VERSION"
+  git commit --quiet --all --message="Prepare release v$NEW_VERSION"
   git tag "v$NEW_TAG"
 fi
 
@@ -198,13 +198,13 @@ post_release_java
 post_release_ruby
 
 if [[ -z $NO_GIT_COMMIT ]]; then
-  git commit -am "Prepare for the next development iteration"
+  git commit --quiet --all --message="Prepare for the next development iteration"
 fi
 
 ###
 # push to github
 ##
 if [[ -z $NO_GIT_PUSH ]]; then
-  git push origin
-  git push origin "$(git rev-list --max-count=1 "v$NEW_VERSION"):refs/heads/release/v$NEW_VERSION"
+  git push --quiet origin
+  git push --quiet origin "$(git rev-list --max-count=1 "v$NEW_VERSION"):refs/heads/release/v$NEW_VERSION"
 fi

--- a/release
+++ b/release
@@ -69,7 +69,7 @@ function post_release_ruby() {
 function validate_new_version_argument() {
   if [[ ! "$NEW_VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
     echo "Invalid MAJOR.MINOR.PATCH argument: $NEW_VERSION"
-    showUsage
+    show_usage
     exit 1
   fi
 
@@ -111,7 +111,7 @@ function validate_local_git() {
   fi
 }
 
-function showUsage() {
+function show_usage() {
   echo "Usage: $0 [OPTIONS] MAJOR.MINOR.PATCH"
   echo "OPTIONS:"
   echo "  --help                 shows this help"
@@ -142,12 +142,12 @@ while [[ $# -gt 0 ]]; do
     ;;
   -h | --help)
     echo "Makes a release to GitHub"
-    showUsage
+    show_usage
     exit 0
     ;;
   -* | --*)
     echo "Unknown option $1"
-    showUsage
+    show_usage
     exit 1
     ;;
   *)
@@ -163,7 +163,7 @@ validate_local_git
 if [[ $# -ne 1 ]]; then
   echo "Missing MAJOR.MINOR.PATCH argument. Please specify a version to release."
   echo
-  showUsage
+  show_usage
   echo
   echo "To help you choose the next version, here are the unreleased changes:"
   echo

--- a/release
+++ b/release
@@ -18,6 +18,7 @@ popd () {
 }
 
 function release_javascript() {
+  check_for_tools "npm"
   if [[ -d javascript ]]; then
     pushd javascript
     npm version $NEW_VERSION > /dev/null
@@ -30,6 +31,7 @@ function post_release_javascript() {
 }
 
 function release_java() {
+  check_for_tools "mvn"
   if [[ -d java ]]; then
     pushd java
     mvn --quiet versions:set -DnewVersion="$NEW_VERSION" 2> /dev/null
@@ -38,6 +40,7 @@ function release_java() {
   fi
 }
 function post_release_java() {
+  check_for_tools "mvn"
   if [[ -d java ]]; then
     pushd java
     NEW_VERSION_TEMPLATE="\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT"
@@ -76,23 +79,23 @@ function validate_new_version_argument() {
   fi
 }
 
-function validate_environment() {
+function check_for_tools() {
+  for tool in "$@"
+  do
+    if ! command -v $tool > /dev/null; then
+      echo "$tool is not installed!"
+      missing_tool="true"
+    fi
+  done
+  if [ "$missing_tool" ]; then
+    echo
+    echo "Please install the missing required tool(s)."
+    exit 1
+  fi
+}
 
-   required_tools=("git" "changelog")
-   [[ -d javascript ]] && required_tools+=("npm")
-   [[ -d java ]] && required_tools+=("mvn")
-   for tool in ${required_tools[@]}
-   do
-     if ! command -v $tool > /dev/null; then
-       echo "$tool is not installed!"
-       missing_tool="true"
-     fi
-   done
-   if [ "$missing_tool" ]; then
-     echo
-     echo "Please install the missing required tool(s)."
-     exit 1
-   fi
+function validate_local_git() {
+  check_for_tools "git" "changelog"
 
   if [[ (-z $NO_GIT_TAG_CHECK) && (-z "$(git tag --list "v$(changelog latest)")") ]]; then
     echo "No git tag found for v$(changelog latest) (found in CHANGELOG.md)!"
@@ -156,7 +159,7 @@ done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
-validate_environment
+validate_local_git
 if [[ $# -ne 1 ]]; then
   echo "Missing MAJOR.MINOR.PATCH argument. Please specify a version to release."
   echo

--- a/release
+++ b/release
@@ -63,7 +63,7 @@ function post_release_ruby() {
   :
 }
 
-function validate_args() {
+function validate_new_version_argument() {
   if [[ ! "$NEW_VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
     echo "Invalid MAJOR.MINOR.PATCH argument: $NEW_VERSION"
     showUsage
@@ -166,7 +166,7 @@ if [[ $# -ne 1 ]]; then
 fi
 NEW_VERSION=$1
 
-validate_args
+validate_new_version_argument
 
 ###
 ## release

--- a/release
+++ b/release
@@ -55,14 +55,22 @@ function validate_args() {
   fi
 
   if [ -n "$(git tag --list "v$NEW_VERSION")" ]; then
-    echo "Version $NEW_VERSION has already been released"
+    echo "Version $NEW_VERSION has already been released."
     exit 1
   fi
 }
 
 function validate_environment() {
+  if [[ (-z $NO_GIT_TAG_CHECK) && (-z "$(git tag --list "v$(changelog latest)")") ]]; then
+    echo "No git tag found for v$(changelog latest) (found in CHANGELOG.md)!"
+    echo
+    echo "Do you need to run this?"
+    echo "    git fetch --tags"
+    exit 1
+  fi
+
   if ! git diff-index --quiet HEAD; then
-    echo "Git has uncommitted changes"
+    echo "Git has uncommitted changes."
     exit 1
   fi
 }
@@ -83,10 +91,11 @@ function validate_environment() {
 function showUsage() {
   echo "Usage: $0 [OPTIONS] MAJOR.MINOR.PATCH"
   echo "OPTIONS:"
-  echo "  --help             shows this help"
-  echo "  --no-git-push      do not push to git"
-  echo "  --no-git-commit    do not commit git"
-  echo "  --only-release     do not update versions after release"
+  echo "  --help                 shows this help"
+  echo "  --no-git-push          do not push to git"
+  echo "  --no-git-commit        do not commit git"
+  echo "  --no-git-tag-check     do not check local git tags are up to date with CHANGELOG.md"
+  echo "  --only-release         do not update versions after release"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -98,6 +107,10 @@ while [[ $# -gt 0 ]]; do
   --no-git-commit)
     NO_GIT_COMMIT="true"
     NO_GIT_PUSH="true"
+    shift # past argument
+    ;;
+  --no-git-tag-check)
+    NO_GIT_TAG_CHECK="true"
     shift # past argument
     ;;
   --only-release)

--- a/release
+++ b/release
@@ -108,7 +108,6 @@ function validate_environment() {
   fi
 }
 
-
 function showUsage() {
   echo "Usage: $0 [OPTIONS] MAJOR.MINOR.PATCH"
   echo "OPTIONS:"
@@ -158,14 +157,18 @@ done
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 validate_environment
-
 if [[ $# -ne 1 ]]; then
-  echo "Missing MAJOR.MINOR.PATCH argument"
+  echo "Missing MAJOR.MINOR.PATCH argument. Please specify a version to release."
+  echo
   showUsage
+  echo
+  echo "To help you choose the next version, here are the unreleased changes:"
+  echo
+  echo "$(changelog show unreleased)"
+  echo
   exit 1
 fi
 NEW_VERSION=$1
-
 validate_new_version_argument
 
 ###

--- a/release-test
+++ b/release-test
@@ -1,51 +1,53 @@
 #!/bin/bash
 
+FAILURE=
+
+function start_test() {
+    echo -n $1
+}
+
+function finish_test() {
+    if [[ $? != 0 ]]; then
+      FAILURE="true"
+      echo " 🔴"
+    else
+      echo " ✅"
+    fi
+}
+
 if ! git diff-index --quiet HEAD; then
   echo "Git has uncommitted changes"
   exit 1
 fi
 
-echo -n "## 01: Release and post release "
+start_test "## 01: Release and post release"
 pushd test-fixture > /dev/null
 ../release 1.0.0 --no-git-commit --no-git-tag-check
 popd > /dev/null
 git diff --unified=0 > 01-actual.diff
 sed -i.bak '/^index/d' 01-actual.diff
-cat 01-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 01-actual.diff -
-if [[ $? != 0 ]]; then
-  failure="true"
-  echo "🛑"
-else
-  echo "✅"
-fi
+sed -i.bak 's/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/2000-01-01/g' 01-actual.diff
+diff 01-expected.diff 01-actual.diff
+finish_test
 git restore --source=HEAD --staged --worktree -- test-fixture
 
-echo -n "## 02: Only release "
+start_test "## 02: Only release "
 pushd test-fixture > /dev/null
 ../release 1.0.0 --no-git-commit --no-git-tag-check --only-release
 popd > /dev/null
 git diff --unified=0 > 02-actual.diff
 sed -i.bak '/^index/d' 02-actual.diff
-cat 02-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 02-actual.diff -
-if [[ $? != 0 ]]; then
-  failure="true"
-  echo "🛑"
-else
-  echo "✅"
-fi
+sed -i.bak 's/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/2000-01-01/g' 02-actual.diff
+diff 02-expected.diff 02-actual.diff
+finish_test
 git restore --source=HEAD --staged --worktree -- test-fixture
 
-echo -n "## 03: Show unreleased changes "
+start_test "## 03: Show unreleased changes "
 pushd test-fixture > /dev/null
 ../release --no-git-tag-check > ../03-actual.output
 popd > /dev/null
 diff 03-expected.output 03-actual.output
-if [[ $? != 0 ]]; then
-  failure="true"
-  echo "🛑"
-else
-  echo "✅"
-fi
+finish_test
 git restore --source=HEAD --staged --worktree -- test-fixture
 
-test -z $failure
+test -z $FAILURE

--- a/release-test
+++ b/release-test
@@ -6,9 +6,9 @@ if ! git diff-index --quiet HEAD; then
 fi
 
 echo "## 01: Release and post release"
-pushd test-fixture
+pushd test-fixture > /dev/null
 ../release 1.0.0 --no-git-commit --no-git-tag-check
-popd
+popd > /dev/null
 git diff --unified=0 > 01-actual.diff
 sed -i.bak '/^index/d' 01-actual.diff
 cat 01-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 01-actual.diff -
@@ -16,9 +16,9 @@ cat 01-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 01-actual.diff -
 git restore --source=HEAD --staged --worktree -- test-fixture
 
 echo "## 02: Only release"
-pushd test-fixture
+pushd test-fixture > /dev/null
 ../release 1.0.0 --no-git-commit --no-git-tag-check --only-release
-popd
+popd > /dev/null
 git diff --unified=0 > 02-actual.diff
 sed -i.bak '/^index/d' 02-actual.diff
 cat 02-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 02-actual.diff -
@@ -26,9 +26,9 @@ cat 02-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 02-actual.diff -
 git restore --source=HEAD --staged --worktree -- test-fixture
 
 echo "03: Show unreleased changes"
-pushd test-fixture
+pushd test-fixture > /dev/null
 ../release --no-git-tag-check > ../03-actual.output
-popd
+popd > /dev/null
 diff 03-expected.output 03-actual.output
 [[ $? != 0 ]] && failure="true"
 git restore --source=HEAD --staged --worktree -- test-fixture

--- a/release-test
+++ b/release-test
@@ -5,32 +5,47 @@ if ! git diff-index --quiet HEAD; then
   exit 1
 fi
 
-echo "## 01: Release and post release"
+echo -n "## 01: Release and post release "
 pushd test-fixture > /dev/null
 ../release 1.0.0 --no-git-commit --no-git-tag-check
 popd > /dev/null
 git diff --unified=0 > 01-actual.diff
 sed -i.bak '/^index/d' 01-actual.diff
 cat 01-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 01-actual.diff -
-[[ $? != 0 ]] && failure="true"
+if [[ $? != 0 ]]; then
+  failure="true"
+  echo "🛑"
+else
+  echo "✅"
+fi
 git restore --source=HEAD --staged --worktree -- test-fixture
 
-echo "## 02: Only release"
+echo -n "## 02: Only release "
 pushd test-fixture > /dev/null
 ../release 1.0.0 --no-git-commit --no-git-tag-check --only-release
 popd > /dev/null
 git diff --unified=0 > 02-actual.diff
 sed -i.bak '/^index/d' 02-actual.diff
 cat 02-expected.diff | sed 's/2022-04-07/2022-04-08/' | diff 02-actual.diff -
-[[ $? != 0 ]] && failure="true"
+if [[ $? != 0 ]]; then
+  failure="true"
+  echo "🛑"
+else
+  echo "✅"
+fi
 git restore --source=HEAD --staged --worktree -- test-fixture
 
-echo "03: Show unreleased changes"
+echo -n "## 03: Show unreleased changes "
 pushd test-fixture > /dev/null
 ../release --no-git-tag-check > ../03-actual.output
 popd > /dev/null
 diff 03-expected.output 03-actual.output
-[[ $? != 0 ]] && failure="true"
+if [[ $? != 0 ]]; then
+  failure="true"
+  echo "🛑"
+else
+  echo "✅"
+fi
 git restore --source=HEAD --staged --worktree -- test-fixture
 
 test -z $failure

--- a/release-test
+++ b/release-test
@@ -7,7 +7,7 @@ fi
 
 ## 01: Release and post release
 pushd test-fixture
-../release 1.0.0 --no-git-commit
+../release 1.0.0 --no-git-commit --no-git-tag-check
 popd
 git diff --unified=0 > 01-actual.diff
 sed -i.bak '/^index/d' 01-actual.diff
@@ -17,7 +17,7 @@ git restore --source=HEAD --staged --worktree -- test-fixture
 
 ## 02: Only release
 pushd test-fixture
-../release 1.0.0 --no-git-commit --only-release
+../release 1.0.0 --no-git-commit --no-git-tag-check --only-release
 popd
 git diff --unified=0 > 02-actual.diff
 sed -i.bak '/^index/d' 02-actual.diff

--- a/release-test
+++ b/release-test
@@ -25,4 +25,12 @@ diff 02-actual.diff 02-expected.diff
 [[ $? != 0 ]] && failure="true"
 git restore --source=HEAD --staged --worktree -- test-fixture
 
+## 03: Show unreleased changes
+pushd test-fixture
+../release --no-git-tag-check > ../03-actual.output
+popd
+diff 03-actual.output 03-expected.output
+[[ $? != 0 ]] && failure="true"
+git restore --source=HEAD --staged --worktree -- test-fixture
+
 test -z $failure

--- a/test-fixture/CHANGELOG.md
+++ b/test-fixture/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - This is a test
 
-## [0.0.1] - 2022-04-07
+## [0.0.1] - 2000-01-01
 
-## [0.0.0] - 2019-08-23
+## [0.0.0] - 2000-01-01
 
 [Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/test-fixture/CHANGELOG.md
+++ b/test-fixture/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- This is a test
+
 ## [0.0.1] - 2022-04-07
 
 ## [0.0.0] - 2019-08-23


### PR DESCRIPTION
### 🤔 What's changed?

* Factored out the environment / argument integrity guards into functions
* Guard for latest git tags not being fetched locally (the "already released" check would be unreliable otherwise)
* Quiet output from pushd/popd/git/npm
* Check for missing tools in environment
* Show unreleased changes from `CHANGELOG` if user omits release number

### ⚡️ What's your motivation? 

Progress!

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
