### PR TITLE
tell npm not to do a commit and tag itself

### DIFF
--- a/release
+++ b/release
@@ -4,7 +4,7 @@ set -e
 function release_javascript() {
   if [[ -d javascript ]]; then
     pushd javascript
-    npm version $NEW_VERSION
+    npm version $NEW_VERSION --no-git-tag-version
     popd
   fi
 }


### PR DESCRIPTION
Since we do our own commit and tag step. See https://docs.npmjs.com/cli/v8/commands/npm-version#git-tag-version