### PR TITLE
Clearer output when no version specified

### DIFF
--- a/polyglot-release
+++ b/polyglot-release
@@ -192,9 +192,7 @@ check_git_tags_fetched
 check_git_index_clean
 
 if [[ $# -ne 1 ]]; then
-  echo "Missing MAJOR.MINOR.PATCH argument. Please specify a version to release."
-  echo
-  echo "Use --help to show usage."
+  echo "Please specify a version to release. Use --help to show usage instructions."
   echo
   echo "To help you choose the next version, here are the unreleased changes:"
   echo

--- a/polyglot-release
+++ b/polyglot-release
@@ -194,7 +194,7 @@ check_git_index_clean
 if [[ $# -ne 1 ]]; then
   echo "Missing MAJOR.MINOR.PATCH argument. Please specify a version to release."
   echo
-  show_usage
+  echo "Use --help to show usage."
   echo
   echo "To help you choose the next version, here are the unreleased changes:"
   echo

--- a/tests/missing-version--show-unreleased-changes.sh.expected.output
+++ b/tests/missing-version--show-unreleased-changes.sh.expected.output
@@ -1,11 +1,6 @@
 Missing MAJOR.MINOR.PATCH argument. Please specify a version to release.
 
-Usage: polyglot-release [OPTIONS] MAJOR.MINOR.PATCH
-OPTIONS:
-  --help                 shows this help
-  --no-git-push          do not push to git
-  --no-git-commit        do not commit git
-  --only-release         do not update versions after release
+Use --help to show usage.
 
 To help you choose the next version, here are the unreleased changes:
 

--- a/tests/missing-version--show-unreleased-changes.sh.expected.output
+++ b/tests/missing-version--show-unreleased-changes.sh.expected.output
@@ -1,6 +1,4 @@
-Missing MAJOR.MINOR.PATCH argument. Please specify a version to release.
-
-Use --help to show usage.
+Please specify a version to release. Use --help to show usage instructions.
 
 To help you choose the next version, here are the unreleased changes:
 


### PR DESCRIPTION
### 🤔 What's changed?

* modified output when no version specified to not show full usage instructions

### ⚡️ What's your motivation? 

We helpfully show the user a summary of the unreleased changes, but you don't notice that because of the usage instructions.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
