### PR TITLE
Support Go

### DIFF
--- a/polyglot-release
+++ b/polyglot-release
@@ -23,14 +23,14 @@ function is_monoglot_go() {
   [[ -f go.mod ]]
 }
 function pre_release_go() {
-  check_for_tools "go" "jq"
+  check_for_tools "go" "jq" "sed"
 }
 function release_go() {
-  GO_MODULE=$(
+  MODULE_WITH_NEW_VERSION=$(
     go mod edit -json |\
-    jq -r '.Module.Path'
+    jq -r '.Module.Path' |\
+    sed -E "s/(.*)v[0-9]+.[0-9]+.[0-9]+$/\1v$NEW_VERSION/"
   )
-  MODULE_WITH_NEW_VERSION=$(shopt -s extglob; echo "${GO_MODULE/%v+([0-9]).+([0-9]).+([0-9])/}v$NEW_VERSION")
   go mod edit -module "$MODULE_WITH_NEW_VERSION"
 }
 function post_release_go() {

--- a/polyglot-release
+++ b/polyglot-release
@@ -19,6 +19,25 @@ function run() {
   fi
 }
 
+function is_monoglot_go() {
+  [[ -f go.mod ]]
+}
+function pre_release_go() {
+  check_for_tools "go" "jq"
+}
+function release_go() {
+  MODULE_WITH_NEW_VERSION=$(
+    go mod edit -json |\
+    jq -r '.Module.Path' |\
+    sed --regexp-extended "s/(.*)v[0-9]+.[0-9]+.[0-9]+$/\1v$NEW_VERSION/"
+  )
+  go mod edit -module "$MODULE_WITH_NEW_VERSION"
+}
+function post_release_go() {
+  # noop
+  :
+}
+
 function is_monoglot_javascript() {
   [[ -f package.json ]]
 }
@@ -90,7 +109,7 @@ function check_for_tools() {
       missing_tool="true"
     fi
   done
-  if [ "$missing_tool" ]; then
+  if [ -n "$missing_tool" ]; then
     echo
     echo "Please install the missing required tool(s)."
     exit 1
@@ -149,7 +168,7 @@ NO_GIT_PUSH=
 ONLY_RELEASE=
 POSITIONAL_ARGS=()
 RELEASE_DATE=${RELEASE_DATE:-$(date +%F)}
-SUPPORTED_LANGUAGES="java javascript ruby"
+SUPPORTED_LANGUAGES="go java javascript ruby"
 
 while [[ $# -gt 0 ]]; do
   case $1 in

--- a/polyglot-release
+++ b/polyglot-release
@@ -26,11 +26,11 @@ function pre_release_go() {
   check_for_tools "go" "jq"
 }
 function release_go() {
-  MODULE_WITH_NEW_VERSION=$(
+  GO_MODULE=$(
     go mod edit -json |\
-    jq -r '.Module.Path' |\
-    sed --regexp-extended "s/(.*)v[0-9]+.[0-9]+.[0-9]+$/\1v$NEW_VERSION/"
+    jq -r '.Module.Path'
   )
+  MODULE_WITH_NEW_VERSION=$(shopt -s extglob; echo "${GO_MODULE/%v+([0-9]).+([0-9]).+([0-9])/}v$NEW_VERSION")
   go mod edit -module "$MODULE_WITH_NEW_VERSION"
 }
 function post_release_go() {

--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -3,6 +3,7 @@
 FAILURE=
 SRC=$(realpath .)
 GNUPGHOME=$(mktemp -d)
+export GNUPGHOME
 
 function import_gpg_key() {
   gpg --homedir=$GNUPGHOME --batch -q --fast-import "$SRC/tests/gpg-key.private.pgp"
@@ -56,8 +57,6 @@ function run_test() {
   pushd $workdir/local > /dev/null
   PATH=$PATH:$SRC \
     RELEASE_DATE=2000-01-01 \
-    GIT_CONFIG_NOGLOBAL=1 \
-    GNUPGHOME=$GNUPGHOME \
     /bin/sh $test \
     > $test.actual.output \
     2> $test.actual.stderr
@@ -69,7 +68,6 @@ function run_test() {
     > $test.actual.git-log
   popd > /dev/null
   pushd $workdir/origin > /dev/null
-  GNUPGHOME=$GNUPGHOME \
     git log \
     --format="%s %d %GS" \
     > $test.actual.origin-git-log

--- a/tests/fixtures/go/CHANGELOG.md
+++ b/tests/fixtures/go/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Fixed
+- This is a test
+
+## [0.0.1] - 2000-01-01
+
+## [0.0.0] - 2000-01-01
+
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/go/go.mod
+++ b/tests/fixtures/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/project/v0.0.1
+
+go 1.18

--- a/tests/only-release-go.sh
+++ b/tests/only-release-go.sh
@@ -1,0 +1,2 @@
+# fixture: go
+polyglot-release 1.0.0 --no-git-commit --only-release

--- a/tests/only-release-go.sh.expected.git-diff
+++ b/tests/only-release-go.sh.expected.git-diff
@@ -1,0 +1,18 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -9,0 +10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
++## [1.0.0] - 2000-01-01
+@@ -15 +16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+-## [0.0.0] - 2000-01-01
++## 0.0.0 - 2000-01-01
+@@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+diff --git a/go.mod b/go.mod
+--- a/go.mod
++++ b/go.mod
+@@ -1 +1 @@
+-module github.com/example/project/v0.0.1
++module github.com/example/project/v1.0.0


### PR DESCRIPTION
### 🤔 What's changed?

Add support for go.

Fixes #14 

### 🏷️ What kind of change is this?
- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

Go does not provide any utilities to get the version from a module. So to determine the `MODULE_WITH_NEW_VERSION`  string we're using `jq` to select the module name and then parse it using `sed`, This could be a single `sed` command that operates directly on `go.mod`. 

I think this is better because it uses context aware tools rather then interpreting the file but I'm not sure.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
