### PR TITLE
Support GitHub Actions

### DIFF
--- a/polyglot-release
+++ b/polyglot-release
@@ -20,6 +20,23 @@ function run() {
 }
 SUPPORTED_LANGUAGES=()
 
+SUPPORTED_LANGUAGES+=("github-action")
+function is_monoglot_github-action() {
+  [[ -f action.yaml ]]
+}
+function pre_release_github-action() {
+  # noop
+  :
+}
+function release_github-action() {
+  # noop, publishing github only uses git tags
+  :
+}
+function post_release_github-action() {
+  # noop
+  :
+}
+
 SUPPORTED_LANGUAGES+=("go")
 function is_monoglot_go() {
   [[ -f go.mod ]]

--- a/tests/fixtures/github-action/CHANGELOG.md
+++ b/tests/fixtures/github-action/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Fixed
+- This is a test
+
+## [0.0.1] - 2000-01-01
+
+## [0.0.0] - 2000-01-01
+
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/github-action/action.yaml
+++ b/tests/fixtures/github-action/action.yaml
@@ -1,0 +1,8 @@
+name: "Project"
+description: "A Project"
+runs:
+  using: "composite"
+  steps:
+    - name: Hello world
+      run: echo "Hello world"
+      shell: bash

--- a/tests/only-release-github-action.sh
+++ b/tests/only-release-github-action.sh
@@ -1,0 +1,2 @@
+# fixture: github-action
+polyglot-release 1.0.0 --no-git-commit --only-release

--- a/tests/only-release-github-action.sh.expected.git-diff
+++ b/tests/only-release-github-action.sh.expected.git-diff
@@ -1,0 +1,12 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -9,0 +10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
++## [1.0.0] - 2000-01-01
+@@ -15 +16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+-## [0.0.0] - 2000-01-01
++## 0.0.0 - 2000-01-01
+@@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main


### PR DESCRIPTION
### 🤔 What's changed?

Add support for Github Actions.

Fixes: #24 

### ♻️ Anything particular you want feedback on?

Another no-op implementation. 

And we don't actually have any polyglot repo's that include github actions so I've chosen `github-action` as the directory name should we ever include github actions in polyglot project.