### PR TITLE
Add linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install `shellcheck` tool
+        run: sudo apt-get install shellcheck
       - name: Install `changelog` tool
         run: |
           mkdir -p $HOME/.local/bin

--- a/polyglot-release
+++ b/polyglot-release
@@ -149,7 +149,7 @@ function validate_new_version_argument() {
 
 function check_for_tools() {
   for tool in "$@"; do
-    if ! command -v $tool >/dev/null; then
+    if ! command -v "$tool" >/dev/null; then
       echo "$tool is not installed!"
       missing_tool="true"
     fi
@@ -170,7 +170,7 @@ function check_changelog_exists() {
 
 function check_in_git_root_directory() {
   git_root=$(git rev-parse --show-toplevel)
-  pwd=$(realpath $(pwd))
+  pwd=$(realpath "$(pwd)")
   if [[ "$git_root" != "$pwd" ]]; then
     relative_path=$(realpath --relative-to="$(pwd)" "$git_root")
     echo "You're not in the root directory of your git repo!"
@@ -182,14 +182,15 @@ function check_in_git_root_directory() {
 }
 
 function check_gpg_keys_configured() {
-  if [[ -z $(git config user.signingkey) ]]; then
+  key="$(git config user.signingkey)"
+  if [[ -z $key ]]; then
     echo "You do not have a user.signingkey configured in git!"
     echo
     echo "All commits need to be signed. Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key"
     exit 1
   fi
-  if [[ ! $(gpg --list-secret-keys | grep $(git config user.signingkey)) ]]; then
-    echo "Your git user.signingkey ($(git config user.signingkey)) was not found in your GPG keys."
+  if ! gpg --list-secret-keys | grep -q "$key"; then
+    echo "Your git user.signingkey ($key) was not found in your GPG keys."
     echo
     echo "To see all your GPG keys, use:"
     echo "    gpg --list-secret-keys"
@@ -290,7 +291,7 @@ if [[ $# -ne 1 ]]; then
   echo
   echo "To help you choose the next version, here are the unreleased changes:"
   echo
-  echo "$(changelog show unreleased)"
+  changelog show unreleased
   echo
   exit 1
 fi
@@ -348,13 +349,13 @@ fi
 ##
 if [[ -z $NO_GIT_PUSH ]]; then
   local_branch=$(git rev-parse --abbrev-ref HEAD)
-  git push --quiet origin $local_branch
+  git push --quiet origin "$local_branch"
   log "All commit(s) pushed to origin/$local_branch"
-  release_commit=$(git rev-list --max-count=1 $TAG)
+  release_commit=$(git rev-list --max-count=1 "$TAG")
   release_branch="release/$TAG"
   git push --quiet origin "$release_commit:refs/heads/$release_branch"
   log "Release commit (tagged with $TAG) pushed to origin/$release_branch"
   if [[ -n $QUIET ]]; then
-    echo $release_branch
+    echo "$release_branch"
   fi
 fi

--- a/polyglot-release-bootstrapper
+++ b/polyglot-release-bootstrapper
@@ -2,4 +2,4 @@
 TMP_FILE=$(mktemp)
 curl --silent -o "$TMP_FILE" https://raw.githubusercontent.com/cucumber/polyglot-release/main/polyglot-release
 chmod 744 "$TMP_FILE"
-$TMP_FILE $@
+$TMP_FILE "$@"

--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -10,35 +10,35 @@ GNUPGHOME=$(mktemp -d)
 export GNUPGHOME
 
 function import_gpg_key() {
-  gpg --homedir=$GNUPGHOME --batch -q --fast-import "$SRC/tests/gpg-key.private.pgp"
+  gpg --homedir="$GNUPGHOME" --batch -q --fast-import "$SRC/tests/gpg-key.private.pgp"
   GPG_KEY_ID=D8C4AB54E1AB7D53
 }
 
 function setup_git_repos() {
   fixture=$1
   mkdir origin
-  pushd origin > /dev/null
+  pushd origin > /dev/null || exit 1
   git init --quiet --bare
   git symbolic-ref HEAD refs/heads/main
-  popd > /dev/null
+  popd > /dev/null || exit 1
   git clone origin local --quiet 2> /dev/null
-  pushd local > /dev/null
+  pushd local > /dev/null || exit 1
   git checkout --quiet -b main
   git config user.email "tests@example.com"
   git config user.name "Cucumber tests"
-  git config user.signingkey $GPG_KEY_ID
-  cp -R $fixture/. . 
+  git config user.signingkey "$GPG_KEY_ID"
+  cp -R "$fixture"/. . 
   git add .
   git commit --message "Initial commit" --quiet
   git tag v0.0.1
   git push --set-upstream origin main --quiet
   git push --tags --quiet
-  popd > /dev/null
+  popd > /dev/null || exit 1
 }
 
 function get_fixture() {
   test=$1
-  header="$(head -n 1 $test)"
+  header="$(head -n 1 "$test")"
   fixture_pattern="# fixture: (.+)"
   if [[ $header =~ $fixture_pattern ]]
   then
@@ -52,23 +52,23 @@ function get_fixture() {
 function setup_workdir() {
   workdir=$1
   fixture=$2
-  pushd $workdir > /dev/null
-  setup_git_repos $fixture
-  popd > /dev/null
+  pushd "$workdir" > /dev/null || exit 1
+  setup_git_repos "$fixture"
+  popd > /dev/null || exit 1
 }
 
 function manual_test() {
   fixture=$1
   workdir=$(mktemp -d)
   import_gpg_key
-  setup_workdir $workdir $fixture
-  pushd $workdir/local > /dev/null
+  setup_workdir "$workdir" "$fixture"
+  pushd "$workdir/local" > /dev/null || exit 1
   PATH=$SRC:$PATH \
     RELEASE_DATE=2000-01-01 \
     GIT_CONFIG_GLOBAL=/dev/null \
     BASH_SILENCE_DEPRECATION_WARNING=1 \
     /bin/bash --init-file <(echo echo "You are in a manual test sandbox. You can safely git push and commits will be pushed to the repo in ../origin")
-  popd > /dev/null
+  popd > /dev/null || exit 1
 }
 
 function run_test() {
@@ -76,42 +76,43 @@ function run_test() {
   test_failed=
   echo -n "${test##*/} "
   workdir=$(mktemp -d)
-  fixture=$(realpath ./tests/fixtures/$(get_fixture $test))
+  fixture=$(realpath "./tests/fixtures/$(get_fixture "$test")")
   import_gpg_key
-  setup_workdir $workdir $fixture
-  pushd $workdir/local > /dev/null
+  setup_workdir "$workdir" "$fixture"
+  pushd "$workdir/local" > /dev/null || exit 1
   PATH=$SRC:$PATH \
     RELEASE_DATE=2000-01-01 \
     GIT_CONFIG_GLOBAL=/dev/null \
-    /bin/sh $test \
-    > $test.actual.output \
-    2> $test.actual.stderr
-  echo $? > $test.actual.exit-status
+    /bin/sh "$test" \
+    > "$test.actual.output" \
+    2> "$test.actual.stderr"
+  echo $? > "$test.actual.exit-status"
   git diff --unified=0 \
     | sed -e '/^index/d' \
-    > $test.actual.git-diff
+    > "$test.actual.git-diff"
   git log --format="%s %d" \
-    > $test.actual.git-log
-  popd > /dev/null
-  pushd $workdir/origin > /dev/null
+    > "$test.actual.git-log"
+  popd > /dev/null || exit 1
+  pushd "$workdir/origin" > /dev/null || exit 1
     git log \
     --format="%s %d %GS" \
-    > $test.actual.origin-git-log
-  popd > /dev/null
+    > "$test.actual.origin-git-log"
+  popd > /dev/null || exit 1
   for type in output git-diff git-log exit-status stderr origin-git-log; do
     if [ -f "$test.expected.$type" ]; then
-      failure=$(diff $test.expected.$type $test.actual.$type)
-      if [[ $? != 0 ]]; then 
-        if [ -z $test_failed ]; then
+      difference=$(diff "$test.expected.$type" "$test.actual.$type")
+      different=$(test $? != 0)
+      if [[ $different ]]; then 
+        if [ -z "$test_failed" ]; then
           echo " 🔴"
         fi
         echo
         echo Actual $type output different to expected!
         echo
-        echo $(realpath --relative-to="$SRC" "$test.expected.$type")
-        echo $(realpath --relative-to="$SRC" "$test.actual.$type")
+        realpath --relative-to="$SRC" "$test.expected.$type"
+        realpath --relative-to="$SRC" "$test.actual.$type"
         echo
-        echo "$failure"
+        echo "$difference"
         test_failed="true";
       fi
     fi
@@ -127,21 +128,20 @@ function run_test() {
   fi
 }
 
-
-if [ $1 ]; then
+if [ "$1" ]; then
   if [[ $1 =~ tests/.*\.sh$ ]]; then
     # Run a single test
-    run_test $(realpath $1)
+    run_test "$(realpath "$1")"
   fi
   if [[ $1 =~ fixtures/ ]]; then
     # Start a manual test session
-    manual_test $(realpath $1)
+    manual_test "$(realpath "$1")"
   fi
 else
   # Run all tests
   tests=$(realpath tests)
-  for test in $tests/*.sh; do
-    run_test $test
+  for test in "$tests"/*.sh; do
+    run_test "$test"
   done
 fi
 test -z $FAILURE

--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+shellcheck polyglot-release*
+set +e
+
 FAILURE=
 SRC=$(realpath .)
 GNUPGHOME=$(mktemp -d)


### PR DESCRIPTION
### 🤔 What's changed?

* Added https://github.com/koalaman/shellcheck to lint our bash

### ⚡️ What's your motivation? 

Catch basic mistakes

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

* Should we add a way to run it separately or is it OK to just roll it in with the tests?
* Are we OK with adding this tool dependency for developers? Should we document it? (or make the script that uses it self-documenting?)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
