### PR TITLE
Push release tag

### DIFF
--- a/polyglot-release
+++ b/polyglot-release
@@ -398,7 +398,7 @@ fi
 ##
 if [[ -z $NO_GIT_PUSH ]]; then
   local_branch=$(git rev-parse --abbrev-ref HEAD)
-  git push --quiet origin "$local_branch" --follow-tags
+  git push --quiet origin "refs/heads/$local_branch" "refs/tags/$TAG"
   log "All commit(s) pushed to origin/$local_branch"
   release_commit=$(git rev-list --max-count=1 "$TAG")
   release_branch="release/$TAG"

--- a/polyglot-release
+++ b/polyglot-release
@@ -398,7 +398,7 @@ fi
 ##
 if [[ -z $NO_GIT_PUSH ]]; then
   local_branch=$(git rev-parse --abbrev-ref HEAD)
-  git push --quiet origin "$local_branch"
+  git push --quiet origin "$local_branch" --follow-tags
   log "All commit(s) pushed to origin/$local_branch"
   release_commit=$(git rev-list --max-count=1 "$TAG")
   release_branch="release/$TAG"

--- a/tests/release.sh.expected.origin-git-log
+++ b/tests/release.sh.expected.origin-git-log
@@ -1,3 +1,3 @@
 Prepare for the next development iteration  (HEAD -> main) user@example.com
-Prepare release v1.0.0  (release/v1.0.0) user@example.com
+Prepare release v1.0.0  (tag: v1.0.0, release/v1.0.0) user@example.com
 Initial commit  (tag: v0.0.1) 


### PR DESCRIPTION
### 🤔 What's changed?

* Add a `--follow-tags` switch to `git push` so our release tag ends up on `origin` (See [here](https://stackoverflow.com/questions/3745135/push-git-commits-tags-simultaneously))
* Modify test for that behaviour

### ⚡️ What's your motivation? 

Make sure tags get pushed to origin! Noticed this as part of #51

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
