### PR TITLE
Capture / compare all git commits in tests

### DIFF
--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -86,6 +86,15 @@ function run_test() {
     > "$test.actual.output" \
     2> "$test.actual.stderr"
   echo $? > "$test.actual.exit-status"
+  first_commit=$(git log main --pretty=%H --reverse | head -n1)
+  git log \
+    --reverse \
+    --patch \
+    --unified=0 \
+    --pretty=%n%x2A%x20%s \
+    "$first_commit..HEAD" \
+    | sed -e '/^index/d' \
+    > "$test.actual.git-commits"
   git diff --unified=0 \
     | sed -e '/^index/d' \
     > "$test.actual.git-diff"
@@ -97,7 +106,7 @@ function run_test() {
     --format="%s %d %GS" \
     > "$test.actual.origin-git-log"
   popd > /dev/null || exit 1
-  for type in output git-diff git-log exit-status stderr origin-git-log; do
+  for type in output git-commits git-diff git-log exit-status stderr origin-git-log; do
     if [ -f "$test.expected.$type" ]; then
       if [[ $(diff "$test.expected.$type" "$test.actual.$type") ]]; then 
         if [ -z "$test_failed" ]; then

--- a/tests/only-release-java.sh
+++ b/tests/only-release-java.sh
@@ -1,2 +1,2 @@
 # fixture: java
-polyglot-release 1.0.0 --no-git-commit --only-release
+polyglot-release 1.0.0

--- a/tests/only-release-java.sh.expected.git-commits
+++ b/tests/only-release-java.sh.expected.git-commits
@@ -1,3 +1,6 @@
+
+* Prepare release v1.0.0
+
 diff --git a/CHANGELOG.md b/CHANGELOG.md
 --- a/CHANGELOG.md
 +++ b/CHANGELOG.md
@@ -19,3 +22,15 @@ diff --git a/pom.xml b/pom.xml
 @@ -15 +15 @@
 -        <tag>HEAD</tag>
 +        <tag>v1.0.0</tag>
+
+* Prepare for the next development iteration
+
+diff --git a/pom.xml b/pom.xml
+--- a/pom.xml
++++ b/pom.xml
+@@ -8 +8 @@
+-    <version>1.0.0</version>
++    <version>1.0.1-SNAPSHOT</version>
+@@ -15 +15 @@
+-        <tag>v1.0.0</tag>
++        <tag>HEAD</tag>


### PR DESCRIPTION
### 🤔 What's changed?

* Added a facility to the test runner to capture the diffs of each of the commits performed during the test run (the initial commit added by the test setup is not included).

### ⚡️ What's your motivation? 

Working towards #49

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I chose to capture the commits in a single file using `git log` but we could also use `git format-patch` to write each commit to a separate file. Would that be preferable?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
