### PR TITLE
Fixes for MacOS. Add MacOS to CI matrix.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
   test:
     strategy:
       matrix:
+        os: macos-latest
+        changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_darwin_amd64.tar.gz
         include:
-          - os: ubuntu-latest
-            changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz
-          - os: macos-latest
-            changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_darwin_amd64.tar.gz
+        - os: ubuntu-latest
+          changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz
     runs-on: runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     strategy:
       matrix:
-        os: macos-latest
-        changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_darwin_amd64.tar.gz
         include:
+        - os: macos-latest
+          changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_darwin_amd64.tar.gz
         - os: ubuntu-latest
           changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          wget -qO- ${{ matrix.changelog }} | tar xvz -C $HOME/.local/bin changelog
+          wget -qO- "${{ matrix.changelog }}" | tar xvz -C $HOME/.local/bin changelog
       - name: Install `xmlstarlet` tool
         run: brew install xmlstarlet
       - run: ./polyglot-release-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,16 +8,23 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz
+          - os: macos-latest
+            changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_darwin_amd64.tar.gz
+    runs-on: runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Install `shellcheck` tool
-        run: sudo apt-get install shellcheck
+        run: brew install shellcheck
       - name: Install `changelog` tool
         run: |
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          wget -qO- https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz | tar xvz -C $HOME/.local/bin changelog
+          wget -qO- ${{ matrix.changelog }} | tar xvz -C $HOME/.local/bin changelog
       - name: Install `xmlstarlet` tool
         run: |
           sudo apt install -y xmlstarlet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Install `coreutils`
+        run: brew install coreutils
+        if: ${{ matrix.os == 'macos-latest' }}
       - name: Install `shellcheck` tool
         run: brew install shellcheck
       - name: Install `changelog` tool

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,5 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           wget -qO- ${{ matrix.changelog }} | tar xvz -C $HOME/.local/bin changelog
       - name: Install `xmlstarlet` tool
-        run: |
-          sudo apt install -y xmlstarlet
+        run: brew install xmlstarlet
       - run: ./polyglot-release-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - os: ubuntu-latest
           changelog: https://github.com/cucumber/changelog/releases/download/0.10.0/changelog_0.10.0_linux_amd64.tar.gz
-    runs-on: runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Install `shellcheck` tool

--- a/polyglot-release
+++ b/polyglot-release
@@ -153,14 +153,12 @@ function pre_release_polyglot-release() {
 }
 function release_polyglot-release() {
   for file in polyglot-release README.md; do
-    sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=$NEW_VERSION/" "$file" > "$file.tmp"
-    mv "$file.tmp" "$file"
+    sed -i".tmp" "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=$NEW_VERSION/" "$file"
   done
 }
 function post_release_polyglot-release() {
-  sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=/" polyglot-release > polyglot-release.tmp
-  mv polyglot-release.tmp polyglot-release
-  chmod +x polyglot-release
+  sed -i".tmp" "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=/" polyglot-release
+  rm -f "polyglot-release.tmp"
 }
 
 SUPPORTED_LANGUAGES+=("python")
@@ -177,9 +175,10 @@ function release_python() {
     PROJECT_FILE=setup.py
   fi
 
-  sed -e "s/\(version *= *\"\)[0-9]*\.[0-9]*\.[0-9]*\(\"\)/\1$NEW_VERSION\2/" \
-  		"$PROJECT_FILE" > "$PROJECT_FILE.tmp"
-  mv "$PROJECT_FILE.tmp" "$PROJECT_FILE"
+  sed -i".tmp" \
+    -e "s/\(version *= *\"\)[0-9]*\.[0-9]*\.[0-9]*\(\"\)/\1$NEW_VERSION\2/" \
+    "$PROJECT_FILE"
+  rm -f "$PROJECT_FILE.tmp"
 }
 function post_release_python() {
   # noop
@@ -344,7 +343,7 @@ Created-by: polyglot-release v${POLYGLOT_RELEASE_VERSION:--develop}"
 NEW_VERSION=
 NO_GIT_PUSH=
 POLYGLOT_RELEASE_VERSION=
-POLYGLOT_RELEASE_GIT_REPO=${POLYGLOT_RELEASE_GIT_REPO:-$(git config --get remote.origin.url)}
+POLYGLOT_RELEASE_GIT_REPO=${POLYGLOT_RELEASE_GIT_REPO:-https://github.com/cucumber/polyglot-release.git}
 QUIET=
 POSITIONAL_ARGS=()
 RELEASE_DATE=${RELEASE_DATE:-$(date +%F)}

--- a/polyglot-release
+++ b/polyglot-release
@@ -378,7 +378,7 @@ done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
-check_for_tools "git" "changelog" "gpg"
+check_for_tools "git" "changelog" "gpg" "realpath"
 check_up_to_date
 check_in_git_root_directory
 check_changelog_exists

--- a/polyglot-release
+++ b/polyglot-release
@@ -178,7 +178,7 @@ function release_python() {
 
   sed -e "s/\(version *= *\"\)[0-9]*\.[0-9]*\.[0-9]*\(\"\)/\1$NEW_VERSION\2/" \
   		"$PROJECT_FILE" > "$PROJECT_FILE.tmp"
-  mv "$PROJECT_FILE.tmp" > "$PROJECT_FILE"
+  mv "$PROJECT_FILE.tmp" "$PROJECT_FILE"
 }
 function post_release_python() {
   # noop

--- a/polyglot-release
+++ b/polyglot-release
@@ -154,6 +154,7 @@ function pre_release_polyglot-release() {
 function release_polyglot-release() {
   for file in polyglot-release README.md; do
     sed -i".tmp" "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=$NEW_VERSION/" "$file"
+    rm -f "polyglot-release.tmp"
   done
 }
 function post_release_polyglot-release() {

--- a/polyglot-release
+++ b/polyglot-release
@@ -160,6 +160,7 @@ function release_polyglot-release() {
 function post_release_polyglot-release() {
   sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=/" polyglot-release > polyglot-release.tmp
   mv polyglot-release.tmp polyglot-release
+  chmod +x polyglot-release
 }
 
 SUPPORTED_LANGUAGES+=("python")

--- a/polyglot-release
+++ b/polyglot-release
@@ -240,7 +240,7 @@ function check_up_to_date() {
 
   # Note: For each signed tag, Github includes a duplicate appended with ^{}
   latest_tag_in_git="$(
-    git ls-remote --tags --sort='version:refname' \
+    git ls-remote --tags --sort='version:refname' $POLYGLOT_RELEASE_GIT_REPO \
     | grep -E "refs/tags/v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^\^]*$" \
     | cut -d '/' -f 3 \
     | tail -n1

--- a/polyglot-release
+++ b/polyglot-release
@@ -152,12 +152,14 @@ function pre_release_polyglot-release() {
   fi
 }
 function release_polyglot-release() {
-    for file in polyglot-release README.md; do
-      sed -i "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=$NEW_VERSION/" "$file"
-    done
+  for file in polyglot-release README.md; do
+    sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=$NEW_VERSION/" "$file" > "$file.tmp"
+    mv "$file.tmp" "$file"
+  done
 }
 function post_release_polyglot-release() {
-  sed -i "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=/" polyglot-release
+  sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=/" polyglot-release > polyglot-release.tmp
+  mv polyglot-release.tmp polyglot-release
 }
 
 SUPPORTED_LANGUAGES+=("python")
@@ -174,9 +176,9 @@ function release_python() {
     PROJECT_FILE=setup.py
   fi
 
-  sed -i \
-  		-e "s/\(version *= *\"\)[0-9]*\.[0-9]*\.[0-9]*\(\"\)/\1$NEW_VERSION\2/" \
-  		"$PROJECT_FILE"
+  sed -e "s/\(version *= *\"\)[0-9]*\.[0-9]*\.[0-9]*\(\"\)/\1$NEW_VERSION\2/" \
+  		"$PROJECT_FILE" > "$PROJECT_FILE.tmp"
+  mv "$PROJECT_FILE.tmp" > "$PROJECT_FILE"
 }
 function post_release_python() {
   # noop
@@ -238,10 +240,10 @@ function check_up_to_date() {
 
   # Note: For each signed tag, Github includes a duplicate appended with ^{}
   latest_tag_in_git="$(
-    git ls-remote --tags --sort='version:refname' "$POLYGLOT_RELEASE_GIT_REPO" 'v*.*.*' \
-    | grep --invert-match '\^{}' \
+    git ls-remote --tags --sort='version:refname' \
+    | grep -E "refs/tags/v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^\^]*$" \
     | cut -d '/' -f 3 \
-    | tail --lines=1
+    | tail -n1
     )"
 
   if [ "v$POLYGLOT_RELEASE_VERSION" == "$latest_tag_in_git" ]; then
@@ -341,7 +343,6 @@ Created-by: polyglot-release v${POLYGLOT_RELEASE_VERSION:--develop}"
 NEW_VERSION=
 NO_GIT_PUSH=
 POLYGLOT_RELEASE_VERSION=
-POLYGLOT_RELEASE_GIT_REPO=${POLYGLOT_RELEASE_GIT_REPO:-https://github.com/cucumber/polyglot-release.git}
 QUIET=
 POSITIONAL_ARGS=()
 RELEASE_DATE=${RELEASE_DATE:-$(date +%F)}

--- a/polyglot-release
+++ b/polyglot-release
@@ -240,7 +240,7 @@ function check_up_to_date() {
 
   # Note: For each signed tag, Github includes a duplicate appended with ^{}
   latest_tag_in_git="$(
-    git ls-remote --tags --sort='version:refname' $POLYGLOT_RELEASE_GIT_REPO \
+    git ls-remote --tags --sort='version:refname' "$POLYGLOT_RELEASE_GIT_REPO" \
     | grep -E "refs/tags/v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^\^]*$" \
     | cut -d '/' -f 3 \
     | tail -n1
@@ -343,6 +343,7 @@ Created-by: polyglot-release v${POLYGLOT_RELEASE_VERSION:--develop}"
 NEW_VERSION=
 NO_GIT_PUSH=
 POLYGLOT_RELEASE_VERSION=
+POLYGLOT_RELEASE_GIT_REPO=${POLYGLOT_RELEASE_GIT_REPO:-$(git config --get remote.origin.url)}
 QUIET=
 POSITIONAL_ARGS=()
 RELEASE_DATE=${RELEASE_DATE:-$(date +%F)}

--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -e

--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -4,12 +4,6 @@ set -e
 shellcheck polyglot-release*
 set +e
 
-# MacOS doesn't have a realpath function
-# https://stackoverflow.com/questions/3572030/bash-script-absolute-path-with-os-x
-function realpath() {
-  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-
 SRC=$(realpath .)
 GNUPGHOME=$(mktemp -d)
 export GNUPGHOME

--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -1,8 +1,15 @@
+
 #!/bin/bash
 
 set -e
 shellcheck polyglot-release*
 set +e
+
+# MacOS doesn't have a realpath function
+# https://stackoverflow.com/questions/3572030/bash-script-absolute-path-with-os-x
+function realpath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
 
 SRC=$(realpath .)
 GNUPGHOME=$(mktemp -d)

--- a/tests/check-up-to-date.sh
+++ b/tests/check-up-to-date.sh
@@ -6,7 +6,8 @@ set -e
 pushd .. > /dev/null
 cp "$(which polyglot-release)" polyglot-release
 chmod 744 ./polyglot-release
-sed -i "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=0.0.1/" polyglot-release
+sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=0.0.1/" polyglot-release > polyglot-release.tmp
+mv polyglot-release.tmp polyglot-release
 popd > /dev/null
 
 # Create a release for v0.0.2 in polyglot-release.git.

--- a/tests/check-up-to-date.sh
+++ b/tests/check-up-to-date.sh
@@ -6,9 +6,7 @@ set -e
 pushd .. > /dev/null
 cp "$(which polyglot-release)" polyglot-release
 chmod 744 ./polyglot-release
-sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=0.0.1/" polyglot-release > polyglot-release.tmp
-mv polyglot-release.tmp polyglot-release
-chmod +x polyglot-release
+sed -i".tmp" "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=0.0.1/" polyglot-release
 popd > /dev/null
 
 # Create a release for v0.0.2 in polyglot-release.git.

--- a/tests/check-up-to-date.sh
+++ b/tests/check-up-to-date.sh
@@ -8,6 +8,7 @@ cp "$(which polyglot-release)" polyglot-release
 chmod 744 ./polyglot-release
 sed "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=0.0.1/" polyglot-release > polyglot-release.tmp
 mv polyglot-release.tmp polyglot-release
+chmod +x polyglot-release
 popd > /dev/null
 
 # Create a release for v0.0.2 in polyglot-release.git.

--- a/tests/created-by-contains-version.sh
+++ b/tests/created-by-contains-version.sh
@@ -7,10 +7,7 @@ pushd .. > /dev/null
 cp "$(which polyglot-release)" polyglot-release
 chmod 744 ./polyglot-release
 # Set the real script to a released version
-sed "s%^POLYGLOT_RELEASE_VERSION=.*$%POLYGLOT_RELEASE_VERSION=0.0.1%" polyglot-release > polyglot-release.tmp
-mv polyglot-release.tmp polyglot-release
-chmod +x polyglot-release
-
+sed -i".tmp" "s%^POLYGLOT_RELEASE_VERSION=.*$%POLYGLOT_RELEASE_VERSION=0.0.1%" polyglot-release
 popd > /dev/null
 
 

--- a/tests/created-by-contains-version.sh
+++ b/tests/created-by-contains-version.sh
@@ -9,6 +9,7 @@ chmod 744 ./polyglot-release
 # Set the real script to a released version
 sed "s%^POLYGLOT_RELEASE_VERSION=.*$%POLYGLOT_RELEASE_VERSION=0.0.1%" polyglot-release > polyglot-release.tmp
 mv polyglot-release.tmp polyglot-release
+chmod +x polyglot-release
 
 popd > /dev/null
 

--- a/tests/created-by-contains-version.sh
+++ b/tests/created-by-contains-version.sh
@@ -7,7 +7,8 @@ pushd .. > /dev/null
 cp "$(which polyglot-release)" polyglot-release
 chmod 744 ./polyglot-release
 # Set the real script to a released version
-sed -i "s%^POLYGLOT_RELEASE_VERSION=.*$%POLYGLOT_RELEASE_VERSION=0.0.1%" polyglot-release
+sed "s%^POLYGLOT_RELEASE_VERSION=.*$%POLYGLOT_RELEASE_VERSION=0.0.1%" polyglot-release > polyglot-release.tmp
+mv polyglot-release.tmp polyglot-release
 
 popd > /dev/null
 


### PR DESCRIPTION
### 🤔 What's changed?

The `polyglot-release` script has been modified to be portable between Linux and MacOS. In particular, `sed -i` is no longer used since it requires an argument on MacOS, but not on Linux.

Furthermore, the tag filtering has been refactored to filter with `grep` rather than relying on `git ls-remote`.
The `POLYGLOT_RELEASE_GIT_REPO` now has a default value: `git config --get remote.origin.url`.

### ⚡️ What's your motivation? 

Release from a mac, not having to specify `POLYGLOT_RELEASE_GIT_REPO` 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
