### PR TITLE
Fix tests that were failling on my machine

### DIFF
--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -33,7 +33,7 @@ function setup_git_repos() {
   git config user.signingkey "$GPG_KEY_ID"
   cp -R "$fixture"/. .
   git add .
-  git commit --message "Initial commit" --quiet
+  git commit --gpg-sign --message "Initial commit" --quiet
   git tag v0.0.1
   git push --set-upstream origin main --quiet
   git push --tags --quiet

--- a/tests/only-release-github-action.sh.expected.origin-git-log
+++ b/tests/only-release-github-action.sh.expected.origin-git-log
@@ -1,2 +1,2 @@
 Prepare release v1.0.0  (HEAD -> main, tag: v1.0.0, release/v1.0.0) user@example.com
-Initial commit  (tag: v0.0.1) 
+Initial commit  (tag: v0.0.1) user@example.com

--- a/tests/release--no-git-push.sh.expected.origin-git-log
+++ b/tests/release--no-git-push.sh.expected.origin-git-log
@@ -1,1 +1,1 @@
-Initial commit  (HEAD -> main, tag: v0.0.1) 
+Initial commit  (HEAD -> main, tag: v0.0.1) user@example.com

--- a/tests/release.sh.expected.origin-git-log
+++ b/tests/release.sh.expected.origin-git-log
@@ -1,3 +1,3 @@
 Prepare for the next development iteration  (HEAD -> main) user@example.com
 Prepare release v1.0.0  (tag: v1.0.0, release/v1.0.0) user@example.com
-Initial commit  (tag: v0.0.1) 
+Initial commit  (tag: v0.0.1) user@example.com


### PR DESCRIPTION
### 🤔 What's changed?

Explicitly enable gpg key signing when creating a commit in the test repo, and expect that in our tests

### ⚡️ What's your motivation? 

Something must have changed in my local configuration, and these tests started failing because the commits were being signed. I'm just making that explicit for everyone.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
