### PR TITLE
go: use only major version in the module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Go: Only  use major version in go module ([#86](https://github.com/cucumber/polyglot-release/pull/86))
 
 ## [1.2.0] - 2022-11-09
 ### Added

--- a/polyglot-release
+++ b/polyglot-release
@@ -106,12 +106,16 @@ function pre_release_go() {
   check_for_tools "go" "jq" "sed"
 }
 function release_go() {
-  MODULE_WITH_NEW_VERSION=$(
+  local new_major_version
+  new_major_version="$(echo "$NEW_VERSION" | sed -E 's/^([0-9]+)\.[0-9]+\.[0-9]+$/\1/')"
+  # The sed below also captures 3-digit versions
+  local module_with_new_version
+  module_with_new_version=$(
     go mod edit -json |
       jq -r '.Module.Path' |
-      sed -E "s/(.*)v[0-9]+.[0-9]+.[0-9]+$/\1v$NEW_VERSION/"
+      sed -E "s/(.*)v[0-9]+(\.[0-9]+\.[0-9]+)?$/\1v$new_major_version/"
   )
-  go mod edit -module "$MODULE_WITH_NEW_VERSION"
+  go mod edit -module "$module_with_new_version"
 }
 function post_release_go() {
   # noop

--- a/tests/fixtures/go-three-digit-version/CHANGELOG.md
+++ b/tests/fixtures/go-three-digit-version/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Fixed
+- This is a test
+
+## [0.0.1] - 2000-01-01
+
+## [0.0.0] - 2000-01-01
+
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/go-three-digit-version/go.mod
+++ b/tests/fixtures/go-three-digit-version/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/project/v0.0.1
+
+go 1.18

--- a/tests/fixtures/go/go.mod
+++ b/tests/fixtures/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/example/project/v0.0.1
+module github.com/example/project/v0
 
 go 1.18

--- a/tests/only-release-go-three-digit-version.sh
+++ b/tests/only-release-go-three-digit-version.sh
@@ -1,0 +1,2 @@
+# fixture: go-three-digit-version
+polyglot-release 1.0.0

--- a/tests/only-release-go-three-digit-version.sh.expected.git-commits
+++ b/tests/only-release-go-three-digit-version.sh.expected.git-commits
@@ -21,5 +21,5 @@ diff --git a/go.mod b/go.mod
 --- a/go.mod
 +++ b/go.mod
 @@ -1 +1 @@
--module github.com/example/project/v0
+-module github.com/example/project/v0.0.1
 +module github.com/example/project/v1


### PR DESCRIPTION
### 🤔 What's changed?

Following on https://github.com/cucumber/messages/pull/107 we can conclude that

1. only major versions should be used in go module files
2. some project will have been released with a major.minor.patch version

This change will ensure that when a new major release is made:

`module github.com/example/project/v0` will become `module github.com/example/project/v1`

and:

`module github.com/example/project/v0.X.X` will become: `module github.com/example/project/v0`.

This should fix the incorrect module names on the next version.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
