### PR TITLE
osx: Wait a little longer for the server to start

### DIFF
--- a/polyglot-release
+++ b/polyglot-release
@@ -335,6 +335,7 @@ function check_up_to_date() {
     return
   fi
 
+  local latest_version
   latest_version=$(latest_tag_in_git)
 
   if [ "v$POLYGLOT_RELEASE_VERSION" == "$latest_version" ]; then

--- a/tests/do-update.sh
+++ b/tests/do-update.sh
@@ -23,7 +23,7 @@ sed -i".tmp" "s/^POLYGLOT_RELEASE_VERSION=.*$/POLYGLOT_RELEASE_VERSION=0.0.2/" .
 python3 -m http.server 2>/dev/null &
 server_pid=$!
 trap 'kill -9 $server_pid' SIGINT SIGQUIT SIGTERM EXIT
-sleep 1 # Wait for server to start
+sleep 2 # Wait for server to start, not very performant in CI
 popd > /dev/null
 
 #  Update polyglot release


### PR DESCRIPTION
### 🤔 What's changed?

It would appear that the `macos-latest` had a performance regression and can
not start the Python server within 1 second.


