### PR TITLE
go: Also update module imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Go: Also update module imports ([#90](https://github.com/cucumber/polyglot-release/pull/90)) 
 
 ## [1.3.0] - 2022-12-02
 ### Fixed
-- Go: Only  use major version in go module ([#86](https://github.com/cucumber/polyglot-release/pull/86))
+- Go: Only use major version in go module ([#86](https://github.com/cucumber/polyglot-release/pull/86))
 
 ## [1.2.0] - 2022-11-09
 ### Added

--- a/polyglot-release
+++ b/polyglot-release
@@ -103,19 +103,20 @@ function is_monoglot_go() {
   [[ -f go.mod ]]
 }
 function pre_release_go() {
-  check_for_tools "go" "jq" "sed"
+  check_for_tools "go" "jq" "sed" "find"
 }
 function release_go() {
+  local module_with_old_version
+  module_with_old_version="$(go mod edit -json | jq -r '.Module.Path' )"
   local new_major_version
   new_major_version="$(echo "$NEW_VERSION" | sed -E 's/^([0-9]+)\.[0-9]+\.[0-9]+$/\1/')"
   # The sed below also captures 3-digit versions
   local module_with_new_version
-  module_with_new_version=$(
-    go mod edit -json |
-      jq -r '.Module.Path' |
-      sed -E "s/(.*)v[0-9]+(\.[0-9]+\.[0-9]+)?$/\1v$new_major_version/"
-  )
+  module_with_new_version="$(echo "$module_with_old_version" | sed -E "s/(.*)v[0-9]+(\.[0-9]+\.[0-9]+)?$/\1v$new_major_version/")"
+
   go mod edit -module "$module_with_new_version"
+  find . -name '*.go' -exec sed -i".tmp" "s#$module_with_old_version#$module_with_new_version#g" {} \;
+  find . -name '*.go.tmp' -exec rm {} \;
 }
 function post_release_go() {
   # noop

--- a/polyglot-release-test
+++ b/polyglot-release-test
@@ -62,7 +62,7 @@ function get_fixture() {
   else
     fixture=polyglot
   fi
-  echo $fixture
+  echo "$fixture"
 }
 
 function setup_workdir() {

--- a/tests/fixtures/go/cli/main.go
+++ b/tests/fixtures/go/cli/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	module "github.com/example/project/v0"
+)
+
+func main() {
+	module.DoSomething()
+}

--- a/tests/only-release-go.sh.expected.git-commits
+++ b/tests/only-release-go.sh.expected.git-commits
@@ -17,6 +17,12 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
 +[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+diff --git a/cli/main.go b/cli/main.go
+--- a/cli/main.go
++++ b/cli/main.go
+@@ -4 +4 @@ import (
+-	module "github.com/example/project/v0"
++	module "github.com/example/project/v1"
 diff --git a/go.mod b/go.mod
 --- a/go.mod
 +++ b/go.mod


### PR DESCRIPTION
### 🤔 What's changed?

Go modules are not only used externally, they are used internally as well. This means that when changed in a release they effectively break the released package.
### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
