### PR TITLE
go: Tag polyglot go releases with go/vVERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Go: Tag polyglot go releases with go/vVERSION ([#93](https://github.com/cucumber/polyglot-release/pull/93))
 
 ## [1.3.1] - 2022-12-17
 ### Fixed

--- a/polyglot-release
+++ b/polyglot-release
@@ -18,9 +18,23 @@ function run() {
     eval "$1_$2"
     popd
   elif eval "is_monoglot_$2"; then
+    IS_CURRENT_LANGUAGE_POLYGLOT=
     eval "$1_$2"
+    IS_CURRENT_LANGUAGE_POLYGLOT=true
   fi
 }
+# Usage 'decorate "prefix" "suffix" "${TAGS{@}}"'
+function decorate() {
+    local prefix=$1
+    local suffix=$2
+    local tags=()
+
+    for tag in "${@:3}" ; do
+      tags+=("${prefix}${tag}${suffix}")
+    done
+    echo "${tags[@]}"
+}
+
 SUPPORTED_LANGUAGES=()
 
 SUPPORTED_LANGUAGES+=("c")
@@ -104,6 +118,10 @@ function is_monoglot_go() {
 }
 function pre_release_go() {
   check_for_tools "go" "jq" "sed" "find"
+  if $IS_CURRENT_LANGUAGE_POLYGLOT; then
+    # Use an additional tag. See: https://go.dev/ref/mod#vcs-version
+    TAGS+=("go/v$NEW_VERSION");
+  fi
 }
 function release_go() {
   local module_with_old_version
@@ -465,12 +483,14 @@ Created-by: polyglot-release v${POLYGLOT_RELEASE_VERSION:--develop}"
 }
 
 # Initialize global variables
+IS_CURRENT_LANGUAGE_POLYGLOT=true
 NEW_VERSION=
 NO_GIT_PUSH=
 POLYGLOT_RELEASE_VERSION=
 POLYGLOT_RELEASE_GIT_REPO=${POLYGLOT_RELEASE_GIT_REPO:-https://github.com/cucumber/polyglot-release}
 POLYGLOT_RELEASE_UPDATE_LOCATION=${POLYGLOT_RELEASE_UPDATE_LOCATION:-https://raw.githubusercontent.com/cucumber/polyglot-release}
 QUIET=
+TAGS=()
 POSITIONAL_ARGS=()
 RELEASE_DATE=${RELEASE_DATE:-$(date +%F)}
 
@@ -530,6 +550,8 @@ if [[ $# -ne 1 ]]; then
   exit 1
 fi
 NEW_VERSION=$1
+NEW_VERSION_TAG="v$NEW_VERSION"
+TAGS+=("$NEW_VERSION_TAG")
 validate_new_version_argument
 
 commit_before_release="$(git rev-parse HEAD)"
@@ -557,10 +579,11 @@ log "Package manager manifests and CHANGELOG.md updated for $NEW_VERSION"
 log "Here's what changed:"
 log "$(git -c color.diff=always diff)"
 
-TAG="v$NEW_VERSION"
-git commit --gpg-sign --quiet --all --message="$(format_commit_message "Prepare release $TAG")"
-git tag --sign --message "$(format_commit_message "$TAG")" "$TAG"
-log "Files committed to to git and tagged '$TAG'"
+git commit --gpg-sign --quiet --all --message="$(format_commit_message "Prepare release $NEW_VERSION_TAG")"
+for tag in "${TAGS[@]}"; do
+  git tag --sign --message "$(format_commit_message "$NEW_VERSION_TAG")" "$tag"
+done
+log "Files committed to to git and tagged $(decorate "'" "'" "${TAGS[@]}")"
 
 ###
 ## post release
@@ -578,13 +601,14 @@ fi
 # push to github
 ##
 local_branch=$(git rev-parse --abbrev-ref HEAD)
-release_commit=$(git rev-list --max-count=1 "$TAG")
-release_branch="release/$TAG"
+release_commit=$(git rev-list --max-count=1 "$NEW_VERSION_TAG")
+release_branch="release/$NEW_VERSION_TAG"
 if [[ -z $NO_GIT_PUSH ]]; then
-  git push --quiet --atomic origin "refs/heads/$local_branch" "refs/tags/$TAG" "$release_commit:refs/heads/$release_branch"
-  log "Tag $TAG pushed to origin"
+  # shellcheck disable=SC2046
+  git push --quiet --atomic origin "refs/heads/$local_branch" $(decorate "refs/tags/" "" "${TAGS[@]}") "$release_commit:refs/heads/$release_branch"
+  log "Tag(s) ${TAGS[*]} pushed to origin"
   log "All commit(s) pushed to origin/$local_branch"
-  log "Release commit (tagged with $TAG) pushed to origin/$release_branch"
+  log "Release commit (tagged with $NEW_VERSION_TAG) pushed to origin/$release_branch"
   if [[ -n $QUIET ]]; then
     echo "$release_branch"
   fi
@@ -592,7 +616,7 @@ else
   log "You now need to eyeball these commits, then push manually:"
   log
   log "# push local commits and tags to $local_branch"
-  log "git push origin refs/heads/$local_branch refs/tags/$TAG"
+  log "git push origin refs/heads/$local_branch $(decorate "refs/tags/" "" "${TAGS[@]}")"
   log
   log "# push to release branch"
   log "git push origin $release_commit:refs/heads/$release_branch"
@@ -604,5 +628,5 @@ else
   log "git reset --hard $commit_before_release"
   log
   log "# delete the git tag that was created"
-  log "git tag -d $TAG"
+  log "git tag -d ${TAGS[*]}"
 fi

--- a/tests/fixtures/go-polyglot/CHANGELOG.md
+++ b/tests/fixtures/go-polyglot/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Fixed
+- This is a test
+
+## [0.0.1] - 2000-01-01
+
+## [0.0.0] - 2000-01-01
+
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/go-polyglot/go/go.mod
+++ b/tests/fixtures/go-polyglot/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/project/v0
+
+go 1.18

--- a/tests/only-release-go-polyglot--no-git-push.sh
+++ b/tests/only-release-go-polyglot--no-git-push.sh
@@ -1,0 +1,2 @@
+# fixture: go-polyglot
+polyglot-release 1.0.0 --no-git-push

--- a/tests/only-release-go-polyglot--no-git-push.sh.expected.git-log
+++ b/tests/only-release-go-polyglot--no-git-push.sh.expected.git-log
@@ -1,0 +1,2 @@
+Prepare release v1.0.0  (HEAD -> main, tag: v1.0.0, tag: go/v1.0.0)
+Initial commit  (tag: v0.0.1, origin/main)

--- a/tests/only-release-go-polyglot--no-git-push.sh.expected.output-normalized
+++ b/tests/only-release-go-polyglot--no-git-push.sh.expected.output-normalized
@@ -1,0 +1,49 @@
+Package manager manifests and CHANGELOG.md updated for 1.0.0
+Here's what changed:
+[1mdiff --git a/CHANGELOG.md b/CHANGELOG.md[m
+[1mindex 5c5d610..e849b16 100644[m
+[1m--- a/CHANGELOG.md[m
+[1m+++ b/CHANGELOG.md[m
+[36m@@ -7,12 +7,14 @@[m [mand this project adheres to [Semantic Versioning](http://semver.org/).[m
+ [m
+ ## [Unreleased][m
+ [m
+[32m+[m[32m## [1.0.0] - 2000-01-01[m
+ ### Fixed[m
+ - This is a test[m
+ [m
+ ## [0.0.1] - 2000-01-01[m
+ [m
+[31m-## [0.0.0] - 2000-01-01[m
+[32m+[m[32m## 0.0.0 - 2000-01-01[m
+ [m
+[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+ [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
+[1mdiff --git a/go/go.mod b/go/go.mod[m
+[1mindex e70a7b9..dd347c7 100644[m
+[1m--- a/go/go.mod[m
+[1m+++ b/go/go.mod[m
+[36m@@ -1,3 +1,3 @@[m
+[31m-module github.com/example/project/v0[m
+[32m+[m[32mmodule github.com/example/project/v1[m
+ [m
+ go 1.18[m
+Files committed to to git and tagged 'v1.0.0' 'go/v1.0.0'
+You now need to eyeball these commits, then push manually:
+
+# push local commits and tags to main
+git push origin refs/heads/main refs/tags/v1.0.0 refs/tags/go/v1.0.0
+
+# push to release branch
+git push origin <a-git-sha>:refs/heads/release/v1.0.0
+
+
+If things do not look quite right you can roll back the release:
+
+# reset to the commit before release started
+git reset --hard <a-git-sha>
+
+# delete the git tag that was created
+git tag -d v1.0.0 go/v1.0.0

--- a/tests/only-release-go-polyglot.sh
+++ b/tests/only-release-go-polyglot.sh
@@ -1,0 +1,2 @@
+# fixture: go-polyglot
+polyglot-release 1.0.0

--- a/tests/only-release-go-polyglot.sh.expected.git-log
+++ b/tests/only-release-go-polyglot.sh.expected.git-log
@@ -1,0 +1,2 @@
+Prepare release v1.0.0  (HEAD -> main, tag: v1.0.0, tag: go/v1.0.0, origin/release/v1.0.0, origin/main)
+Initial commit  (tag: v0.0.1)

--- a/tests/only-release-go-polyglot.sh.expected.output-normalized
+++ b/tests/only-release-go-polyglot.sh.expected.output-normalized
@@ -1,0 +1,36 @@
+Package manager manifests and CHANGELOG.md updated for 1.0.0
+Here's what changed:
+[1mdiff --git a/CHANGELOG.md b/CHANGELOG.md[m
+[1mindex 5c5d610..e849b16 100644[m
+[1m--- a/CHANGELOG.md[m
+[1m+++ b/CHANGELOG.md[m
+[36m@@ -7,12 +7,14 @@[m [mand this project adheres to [Semantic Versioning](http://semver.org/).[m
+ [m
+ ## [Unreleased][m
+ [m
+[32m+[m[32m## [1.0.0] - 2000-01-01[m
+ ### Fixed[m
+ - This is a test[m
+ [m
+ ## [0.0.1] - 2000-01-01[m
+ [m
+[31m-## [0.0.0] - 2000-01-01[m
+[32m+[m[32m## 0.0.0 - 2000-01-01[m
+ [m
+[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+ [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
+[1mdiff --git a/go/go.mod b/go/go.mod[m
+[1mindex e70a7b9..dd347c7 100644[m
+[1m--- a/go/go.mod[m
+[1m+++ b/go/go.mod[m
+[36m@@ -1,3 +1,3 @@[m
+[31m-module github.com/example/project/v0[m
+[32m+[m[32mmodule github.com/example/project/v1[m
+ [m
+ go 1.18[m
+Files committed to to git and tagged 'v1.0.0' 'go/v1.0.0'
+Tag(s) v1.0.0 go/v1.0.0 pushed to origin
+All commit(s) pushed to origin/main
+Release commit (tagged with v1.0.0) pushed to origin/release/v1.0.0

--- a/tests/release.sh.expected.output
+++ b/tests/release.sh.expected.output
@@ -79,6 +79,6 @@ Here's what changed:
 [32m+[m[32m1.0.0[m
 Files committed to to git and tagged 'v1.0.0'
 Post-release changes committed to to git
-Tag v1.0.0 pushed to origin
+Tag(s) v1.0.0 pushed to origin
 All commit(s) pushed to origin/main
 Release commit (tagged with v1.0.0) pushed to origin/release/v1.0.0


### PR DESCRIPTION
> https://go.dev/ref/mod#vcs-version
> If a module is defined in a subdirectory within the repository, that is, the
> module subdirectory portion of the module path is not empty, then each tag
> name must be prefixed with the module subdirectory, followed by a slash. For
> example, the module golang.org/x/tools/gopls is defined in the gopls
> subdirectory of the repository with root path golang.org/x/tools. The
> version v0.4.0 of that module must have the tag named gopls/v0.4.0 in that
> repository.

Currently, releases are only tagged with `vVERSION`. So to make go happy we have to add a `go/vVERSION` tag.

Fixes: #91