### PR TITLE
Fix CHANGELOG unreleased url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,14 +43,14 @@
 ### Added
 - First release of polyglot-release
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.3.2...main
-[1.3.2]: https://github.com/cucumber/polyglot-release/compare/v1.3.1...main
-[1.3.1]: https://github.com/cucumber/polyglot-release/compare/v1.3.0...main
-[1.3.0]: https://github.com/cucumber/polyglot-release/compare/v1.2.0...main
-[1.2.0]: https://github.com/cucumber/polyglot-release/compare/v1.1.0...main
-[1.1.0]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.9.3...main
-[0.9.3]: https://github.com/cucumber/polyglot-release/compare/v0.9.2...main
-[0.9.2]: https://github.com/cucumber/polyglot-release/compare/v0.9.1...main
-[0.9.1]: https://github.com/cucumber/polyglot-release/compare/v0.9.0...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.3.2...HEAD
+[1.3.2]: https://github.com/cucumber/polyglot-release/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/cucumber/polyglot-release/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/cucumber/polyglot-release/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/cucumber/polyglot-release/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/cucumber/polyglot-release/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/cucumber/polyglot-release/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/cucumber/polyglot-release/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/cucumber/polyglot-release/compare/ad3c912c06971aefdd597d7c315ca75fa93ce83f...v0.9.0~~

--- a/polyglot-release
+++ b/polyglot-release
@@ -483,7 +483,6 @@ Created-by: polyglot-release v${POLYGLOT_RELEASE_VERSION:--develop}"
 }
 
 # Initialize global variables
-FIRST_RELEASE=
 IS_CURRENT_LANGUAGE_POLYGLOT=true
 NEW_VERSION=
 NO_GIT_PUSH=

--- a/polyglot-release
+++ b/polyglot-release
@@ -483,6 +483,7 @@ Created-by: polyglot-release v${POLYGLOT_RELEASE_VERSION:--develop}"
 }
 
 # Initialize global variables
+FIRST_RELEASE=
 IS_CURRENT_LANGUAGE_POLYGLOT=true
 NEW_VERSION=
 NO_GIT_PUSH=

--- a/tests/created-by-contains-version.sh.expected.git-commits
+++ b/tests/created-by-contains-version.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/created-by-contains-version.sh.expected.git-commits
+++ b/tests/created-by-contains-version.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/fixtures/c/CHANGELOG.md
+++ b/tests/fixtures/c/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/changelog-with-v-in-headings/CHANGELOG.md
+++ b/tests/fixtures/changelog-with-v-in-headings/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/dotnet-no-cs-project-file/CHANGELOG.md
+++ b/tests/fixtures/dotnet-no-cs-project-file/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/dotnet/CHANGELOG.md
+++ b/tests/fixtures/dotnet/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/elixir/CHANGELOG.md
+++ b/tests/fixtures/elixir/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/github-action/CHANGELOG.md
+++ b/tests/fixtures/github-action/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/go-polyglot/CHANGELOG.md
+++ b/tests/fixtures/go-polyglot/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/go-three-digit-version/CHANGELOG.md
+++ b/tests/fixtures/go-three-digit-version/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/go/CHANGELOG.md
+++ b/tests/fixtures/go/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/java/CHANGELOG.md
+++ b/tests/fixtures/java/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/javascript/CHANGELOG.md
+++ b/tests/fixtures/javascript/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/perl-no-version-file/CHANGELOG.md
+++ b/tests/fixtures/perl-no-version-file/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/perl/CHANGELOG.md
+++ b/tests/fixtures/perl/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/php/CHANGELOG.md
+++ b/tests/fixtures/php/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/polyglot-release/CHANGELOG.md
+++ b/tests/fixtures/polyglot-release/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/polyglot/CHANGELOG.md
+++ b/tests/fixtures/polyglot/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/python-poetry/CHANGELOG.md
+++ b/tests/fixtures/python-poetry/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/python-tox/CHANGELOG.md
+++ b/tests/fixtures/python-tox/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/ruby-no-version-file/CHANGELOG.md
+++ b/tests/fixtures/ruby-no-version-file/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/fixtures/ruby/CHANGELOG.md
+++ b/tests/fixtures/ruby/CHANGELOG.md
@@ -14,5 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.0] - 2000-01-01
 
-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1

--- a/tests/only-release-c.sh.expected.git-commits
+++ b/tests/only-release-c.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/only-release-c.sh.expected.git-commits
+++ b/tests/only-release-c.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/only-release-dotnet.sh.expected.git-commits
+++ b/tests/only-release-dotnet.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/Project/Project.csproj b/Project/Project.csproj
 --- a/Project/Project.csproj
 +++ b/Project/Project.csproj

--- a/tests/only-release-dotnet.sh.expected.git-commits
+++ b/tests/only-release-dotnet.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/Project/Project.csproj b/Project/Project.csproj
 --- a/Project/Project.csproj
 +++ b/Project/Project.csproj

--- a/tests/only-release-elixir.sh.expected.git-commits
+++ b/tests/only-release-elixir.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/mix.exs b/mix.exs
 --- a/mix.exs
 +++ b/mix.exs

--- a/tests/only-release-elixir.sh.expected.git-commits
+++ b/tests/only-release-elixir.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/mix.exs b/mix.exs
 --- a/mix.exs
 +++ b/mix.exs

--- a/tests/only-release-github-action.sh.expected.git-commits
+++ b/tests/only-release-github-action.sh.expected.git-commits
@@ -14,6 +14,6 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD

--- a/tests/only-release-github-action.sh.expected.git-commits
+++ b/tests/only-release-github-action.sh.expected.git-commits
@@ -16,4 +16,4 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0

--- a/tests/only-release-go-polyglot--no-git-push.sh.expected.output-normalized
+++ b/tests/only-release-go-polyglot--no-git-push.sh.expected.output-normalized
@@ -1,7 +1,7 @@
 Package manager manifests and CHANGELOG.md updated for 1.0.0
 Here's what changed:
 [1mdiff --git a/CHANGELOG.md b/CHANGELOG.md[m
-[1mindex 5c5d610..e849b16 100644[m
+[1mindex 1e01735..51739ed 100644[m
 [1m--- a/CHANGELOG.md[m
 [1m+++ b/CHANGELOG.md[m
 [36m@@ -7,12 +7,14 @@[m [mand this project adheres to [Semantic Versioning](http://semver.org/).[m
@@ -19,7 +19,7 @@ Here's what changed:
  [m
 [31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
 [32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/go/go.mod b/go/go.mod[m
 [1mindex e70a7b9..dd347c7 100644[m

--- a/tests/only-release-go-polyglot--no-git-push.sh.expected.output-normalized
+++ b/tests/only-release-go-polyglot--no-git-push.sh.expected.output-normalized
@@ -17,9 +17,9 @@ Here's what changed:
 [31m-## [0.0.0] - 2000-01-01[m
 [32m+[m[32m## 0.0.0 - 2000-01-01[m
  [m
-[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
-[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/go/go.mod b/go/go.mod[m
 [1mindex e70a7b9..dd347c7 100644[m

--- a/tests/only-release-go-polyglot.sh.expected.output-normalized
+++ b/tests/only-release-go-polyglot.sh.expected.output-normalized
@@ -1,7 +1,7 @@
 Package manager manifests and CHANGELOG.md updated for 1.0.0
 Here's what changed:
 [1mdiff --git a/CHANGELOG.md b/CHANGELOG.md[m
-[1mindex 5c5d610..e849b16 100644[m
+[1mindex 1e01735..51739ed 100644[m
 [1m--- a/CHANGELOG.md[m
 [1m+++ b/CHANGELOG.md[m
 [36m@@ -7,12 +7,14 @@[m [mand this project adheres to [Semantic Versioning](http://semver.org/).[m
@@ -19,7 +19,7 @@ Here's what changed:
  [m
 [31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
 [32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/go/go.mod b/go/go.mod[m
 [1mindex e70a7b9..dd347c7 100644[m

--- a/tests/only-release-go-polyglot.sh.expected.output-normalized
+++ b/tests/only-release-go-polyglot.sh.expected.output-normalized
@@ -17,9 +17,9 @@ Here's what changed:
 [31m-## [0.0.0] - 2000-01-01[m
 [32m+[m[32m## 0.0.0 - 2000-01-01[m
  [m
-[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
-[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/go/go.mod b/go/go.mod[m
 [1mindex e70a7b9..dd347c7 100644[m

--- a/tests/only-release-go-three-digit-version.sh.expected.git-commits
+++ b/tests/only-release-go-three-digit-version.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/go.mod b/go.mod
 --- a/go.mod
 +++ b/go.mod

--- a/tests/only-release-go-three-digit-version.sh.expected.git-commits
+++ b/tests/only-release-go-three-digit-version.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/go.mod b/go.mod
 --- a/go.mod
 +++ b/go.mod

--- a/tests/only-release-go.sh.expected.git-commits
+++ b/tests/only-release-go.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/cli/main.go b/cli/main.go
 --- a/cli/main.go
 +++ b/cli/main.go

--- a/tests/only-release-go.sh.expected.git-commits
+++ b/tests/only-release-go.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/cli/main.go b/cli/main.go
 --- a/cli/main.go
 +++ b/cli/main.go

--- a/tests/only-release-java.sh.expected.git-commits
+++ b/tests/only-release-java.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/pom.xml b/pom.xml
 --- a/pom.xml
 +++ b/pom.xml

--- a/tests/only-release-java.sh.expected.git-commits
+++ b/tests/only-release-java.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/pom.xml b/pom.xml
 --- a/pom.xml
 +++ b/pom.xml

--- a/tests/only-release-javascript.sh.expected.git-commits
+++ b/tests/only-release-javascript.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/package-lock.json b/package-lock.json
 --- a/package-lock.json
 +++ b/package-lock.json

--- a/tests/only-release-javascript.sh.expected.git-commits
+++ b/tests/only-release-javascript.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/package-lock.json b/package-lock.json
 --- a/package-lock.json
 +++ b/package-lock.json

--- a/tests/only-release-perl.sh.expected.git-commits
+++ b/tests/only-release-perl.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/only-release-perl.sh.expected.git-commits
+++ b/tests/only-release-perl.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/only-release-php.sh.expected.git-commits
+++ b/tests/only-release-php.sh.expected.git-commits
@@ -14,6 +14,6 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD

--- a/tests/only-release-php.sh.expected.git-commits
+++ b/tests/only-release-php.sh.expected.git-commits
@@ -16,4 +16,4 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0

--- a/tests/only-release-polyglot-release.sh.expected.git-commits
+++ b/tests/only-release-polyglot-release.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/README.md b/README.md
 --- a/README.md
 +++ b/README.md

--- a/tests/only-release-polyglot-release.sh.expected.git-commits
+++ b/tests/only-release-polyglot-release.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/README.md b/README.md
 --- a/README.md
 +++ b/README.md

--- a/tests/only-release-python-poetry.sh.expected.git-commits
+++ b/tests/only-release-python-poetry.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/pyproject.toml b/pyproject.toml
 --- a/pyproject.toml
 +++ b/pyproject.toml

--- a/tests/only-release-python-poetry.sh.expected.git-commits
+++ b/tests/only-release-python-poetry.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/pyproject.toml b/pyproject.toml
 --- a/pyproject.toml
 +++ b/pyproject.toml

--- a/tests/only-release-python-tox.sh.expected.git-commits
+++ b/tests/only-release-python-tox.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/setup.py b/setup.py
 --- a/setup.py
 +++ b/setup.py

--- a/tests/only-release-python-tox.sh.expected.git-commits
+++ b/tests/only-release-python-tox.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/setup.py b/setup.py
 --- a/setup.py
 +++ b/setup.py

--- a/tests/only-release-ruby.sh.expected.git-commits
+++ b/tests/only-release-ruby.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/only-release-ruby.sh.expected.git-commits
+++ b/tests/only-release-ruby.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/VERSION b/VERSION
 --- a/VERSION
 +++ b/VERSION

--- a/tests/release--no-git-push.sh.expected.output-normalized
+++ b/tests/release--no-git-push.sh.expected.output-normalized
@@ -17,9 +17,9 @@ Here's what changed:
 [31m-## [0.0.0] - 2000-01-01[m
 [32m+[m[32m## 0.0.0 - 2000-01-01[m
  [m
-[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
-[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/java/pom.xml b/java/pom.xml[m
 [1mindex 1ddc4c5..6879b6c 100644[m

--- a/tests/release--no-git-push.sh.expected.output-normalized
+++ b/tests/release--no-git-push.sh.expected.output-normalized
@@ -1,7 +1,7 @@
 Package manager manifests and CHANGELOG.md updated for 1.0.0
 Here's what changed:
 [1mdiff --git a/CHANGELOG.md b/CHANGELOG.md[m
-[1mindex 5c5d610..e849b16 100644[m
+[1mindex 1e01735..51739ed 100644[m
 [1m--- a/CHANGELOG.md[m
 [1m+++ b/CHANGELOG.md[m
 [36m@@ -7,12 +7,14 @@[m [mand this project adheres to [Semantic Versioning](http://semver.org/).[m
@@ -19,7 +19,7 @@ Here's what changed:
  [m
 [31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
 [32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/java/pom.xml b/java/pom.xml[m
 [1mindex 1ddc4c5..6879b6c 100644[m

--- a/tests/release.sh.expected.git-commits
+++ b/tests/release.sh.expected.git-commits
@@ -16,7 +16,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 +[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0
 diff --git a/java/pom.xml b/java/pom.xml
 --- a/java/pom.xml
 +++ b/java/pom.xml

--- a/tests/release.sh.expected.git-commits
+++ b/tests/release.sh.expected.git-commits
@@ -14,9 +14,9 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 -## [0.0.0] - 2000-01-01
 +## 0.0.0 - 2000-01-01
 @@ -17 +18,2 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
--[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
-+[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main
-+[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main
+-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
++[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD
++[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD
 diff --git a/java/pom.xml b/java/pom.xml
 --- a/java/pom.xml
 +++ b/java/pom.xml

--- a/tests/release.sh.expected.output
+++ b/tests/release.sh.expected.output
@@ -17,9 +17,9 @@ Here's what changed:
 [31m-## [0.0.0] - 2000-01-01[m
 [32m+[m[32m## 0.0.0 - 2000-01-01[m
  [m
-[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
-[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...main[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...main[m
+[31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/java/pom.xml b/java/pom.xml[m
 [1mindex 1ddc4c5..6879b6c 100644[m

--- a/tests/release.sh.expected.output
+++ b/tests/release.sh.expected.output
@@ -1,7 +1,7 @@
 Package manager manifests and CHANGELOG.md updated for 1.0.0
 Here's what changed:
 [1mdiff --git a/CHANGELOG.md b/CHANGELOG.md[m
-[1mindex 5c5d610..e849b16 100644[m
+[1mindex 1e01735..51739ed 100644[m
 [1m--- a/CHANGELOG.md[m
 [1m+++ b/CHANGELOG.md[m
 [36m@@ -7,12 +7,14 @@[m [mand this project adheres to [Semantic Versioning](http://semver.org/).[m
@@ -19,7 +19,7 @@ Here's what changed:
  [m
 [31m-[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
 [32m+[m[32m[Unreleased]: https://github.com/cucumber/polyglot-release/compare/v1.0.0...HEAD[m
-[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...HEAD[m
+[32m+[m[32m[1.0.0]: https://github.com/cucumber/polyglot-release/compare/v0.0.1...v1.0.0[m
  [0.0.1]: https://github.com/cucumber/polyglot-release/compare/v0.0.0...v0.0.1[m
 [1mdiff --git a/java/pom.xml b/java/pom.xml[m
 [1mindex 1ddc4c5..6879b6c 100644[m


### PR DESCRIPTION
The `changelog` tool expects that the unreleased url ends with `...HEAD`
