### PR TITLE
Remove dependency on Homebrew/actions/setup-homebrew

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: Homebrew/actions/setup-homebrew@9926e3be887aa6c9523a027099bf5e882056f5c1 # main
       - run: brew install xmlstarlet shellcheck go coreutils
       - name: Install `changelog` tool
         run: |


### PR DESCRIPTION
### 🤔 What's changed?

Remove dependency on Homebrew/actions/setup-homebrew

It comes [preinstalled with the macos-latest image](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md).

### ⚡️ What's your motivation? 

This removes an unversioned dependency from CI.


### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)

